### PR TITLE
[Mobile CI] Update build badge URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Outline the examples in the repository.
 
 | Example | Description | Pipeline Status |
 |-|-|-|
-| [Mobile examples](mobile) | Examples that demonstrate how to use ONNX Runtime Mobile in mobile applications. | [![Build Status](https://dev.azure.com/onnxruntime/onnxruntime/_apis/build/status/171)](https://dev.azure.com/onnxruntime/onnxruntime/_build/latest?definitionId=171) |
+| [Mobile examples](mobile) | Examples that demonstrate how to use ONNX Runtime Mobile in mobile applications. | [![Build Status](https://dev.azure.com/aiinfra/Lotus/_apis/build/status/996)](https://dev.azure.com/aiinfra/Lotus/_build/latest?definitionId=996) |
 | [JavaScript API examples](js) | Examples that demonstrate how to use JavaScript API for ONNX Runtime. | |
 
 ## Contributing


### PR DESCRIPTION
Moved the CI build definition. This change updates the URLs in the readme accordingly.