### PR TITLE
Update Pipeline Status Badge in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Outline the examples in the repository.
 
 | Example | Description | Pipeline Status |
 |-|-|-|
-| [Mobile examples](mobile) | Examples that demonstrate how to use ONNX Runtime Mobile in mobile applications. | [![Build Status](https://dev.azure.com/aiinfra/Lotus/_apis/build/status/996)](https://dev.azure.com/aiinfra/Lotus/_build/latest?definitionId=996) |
+| [Mobile examples](mobile) | Examples that demonstrate how to use ONNX Runtime Mobile in mobile applications. | [![Build Status](https://dev.azure.com/ms/onnxruntime-inference-examples/_apis/build/status/mobile-examples-ci-pipeline?branchName=main)](https://dev.azure.com/ms/onnxruntime-inference-examples/_build/latest?definitionId=506&branchName=main) |
 | [JavaScript API examples](js) | Examples that demonstrate how to use JavaScript API for ONNX Runtime. | |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Outline the examples in the repository.
 
 | Example | Description | Pipeline Status |
 |-|-|-|
+| [C/C++ examples](c_cxx) |  Examples for ONNX Runtime C/C++ APIs | [![Linux-CPU](https://github.com/microsoft/onnxruntime-inference-examples/actions/workflows/linux-ci.yml/badge.svg)](https://github.com/microsoft/onnxruntime-inference-examples/actions/workflows/linux-ci.yml) [![Windows-CPU](https://github.com/microsoft/onnxruntime-inference-examples/actions/workflows/win-ci.yml/badge.svg)](https://github.com/microsoft/onnxruntime-inference-examples/actions/workflows/win-ci.yml) |
 | [Mobile examples](mobile) | Examples that demonstrate how to use ONNX Runtime Mobile in mobile applications. | [![Build Status](https://dev.azure.com/ms/onnxruntime-inference-examples/_apis/build/status/mobile-examples-ci-pipeline?branchName=main)](https://dev.azure.com/ms/onnxruntime-inference-examples/_build/latest?definitionId=506&branchName=main) |
 | [JavaScript API examples](js) | Examples that demonstrate how to use JavaScript API for ONNX Runtime. | |
 


### PR DESCRIPTION
1. The old one for Mobile examples is not visible from public. The new one is.   I moved the build pipeline.
2. Add badges for the new pipelines.
