### PR TITLE
Add squeezenet to CI build

### DIFF
--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -199,11 +199,11 @@ extends:
             artifactName: 'onnxruntime-win-x64-cuda'
             targetPath: $(Build.BinariesDirectory)
 
-        - script: |
+        - powershell: |
             dir
-            move onnxruntime-win-x64-cuda onnxruntimebin
+            Get-ChildItem -Path *.zip | foreach {7z x $_.fullname; move $_.BaseName onnxruntimebin}
           workingDirectory: '$(Build.BinariesDirectory)'
-          displayName: 'Rename onnxruntime binary folder'
+          displayName: 'Unzip onnxruntime binary'
 
         #TODO: use the vsdevcmd variable
         - script: |

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -130,7 +130,7 @@ extends:
             7z x onnxruntime.zip
             move onnxruntime-win-x64-1.10.0 onnxruntimebin
           workingDirectory: '$(Build.BinariesDirectory)'
-          displayName: 'Install python modules' 
+          displayName: 'Download onnxruntime binary' 
         #TODO: use the vsdevcmd variable
         - script: |
             call $(vsdevcmd)
@@ -158,3 +158,78 @@ extends:
           inputs:
             SourceFolder: $(Build.BinariesDirectory)\onnxruntimebin
             Contents: '*.dll'
+            
+    - stage: Windows_Build_Nightly
+      jobs:
+      - job: main
+        pool:
+          type: windows  
+        
+        variables:
+          ob_outputDirectory: '$(REPOROOT)\out'
+          ob_sdl_binskim_break: true 
+          ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+            ob_symbolsPublishing_enabled: true
+        steps:
+        - checkout: vcpkg
+        - script: |
+            @echo off
+            set vswherepath="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+            for /f "usebackq delims=" %%i in (`%vswherepath% -latest -property installationPath`) do (
+              set vslatest="%%i"
+              if exist "%%i\Common7\Tools\vsdevcmd.bat" (
+                set vsdevcmd="%%i\Common7\Tools\vsdevcmd.bat"
+              )
+            )
+            
+            @echo vslatest %vslatest%
+            @echo vsdevcmd %vsdevcmd%
+            
+            @echo ##vso[task.setvariable variable=vslatest]%vslatest%
+            @echo ##vso[task.setvariable variable=vsdevcmd]%vsdevcmd%
+          displayName: 'locate vsdevcmd via vswhere'
+
+
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download onnxruntime binary'
+          inputs:
+            buildType: specific
+            project: '530acbc4-21bc-487d-8cd8-348ff451d2ff'
+            definition: 940
+            artifactName: 'onnxruntime-win-x64-cuda'
+            targetPath: $(Build.BinariesDirectory)
+
+        - script: |
+            dir
+            move onnxruntime-win-x64-cuda onnxruntimebin
+          workingDirectory: '$(Build.BinariesDirectory)'
+          displayName: 'Rename onnxruntime binary folder'
+
+        #TODO: use the vsdevcmd variable
+        - script: |
+            call $(vsdevcmd)
+            call .\vcpkg\bootstrap-vcpkg.bat
+            cd $(Build.BinariesDirectory)
+            mkdir build
+            cd build
+            cmake $(REPOROOT)\c_cxx -A x64 -T host=x64 -DCMAKE_TOOLCHAIN_FILE=$(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static "-DONNXRUNTIME_ROOTDIR=$(Build.BinariesDirectory)/onnxruntimebin"
+              
+        - task: VSBuild@1
+          displayName: 'Build'
+          inputs:
+            solution: '$(Build.BinariesDirectory)\build\onnxruntime_samples.sln'
+            platform: x64
+            configuration: Release
+            msbuildArchitecture: x64
+            maximumCpuCount: true
+            logProjectEvents: true
+            workingFolder: '$(Build.BinariesDirectory)\build'
+            createLogFile: true
+
+        #Delete onnxruntime.dll which isn't compliant yet.
+        - task: DeleteFiles@1
+          displayName: 'Delete DLLs from onnxruntimebin'
+          inputs:
+            SourceFolder: $(Build.BinariesDirectory)\onnxruntimebin
+            Contents: '*.dll'
+            

--- a/c_cxx/CMakeLists.txt
+++ b/c_cxx/CMakeLists.txt
@@ -30,6 +30,7 @@ if(NOT ONNXRUNTIME_ROOTDIR)
   endif()
 endif()
 
+#TODO: we should only need one of them.
 include_directories("${ONNXRUNTIME_ROOTDIR}/include" "${ONNXRUNTIME_ROOTDIR}/include/onnxruntime/core/session")
 link_directories("${ONNXRUNTIME_ROOTDIR}/lib")
 
@@ -76,6 +77,7 @@ if(WIN32)
   add_subdirectory(imagenet)
   add_subdirectory(MNIST)
 endif()
+add_subdirectory(squeezenet)
 if(PNG_FOUND)
   add_subdirectory(fns_candy_style_transfer)
 endif()

--- a/c_cxx/squeezenet/CMakeLists.txt
+++ b/c_cxx/squeezenet/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
 
 # tensorrt_provider_factory.h contains old APIs of the tensorrt execution provider
-include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 CHECK_INCLUDE_FILE_CXX(tensorrt_provider_factory.h HAVE_TENSORRT_PROVIDER_FACTORY_H)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/c_cxx/squeezenet/CMakeLists.txt
+++ b/c_cxx/squeezenet/CMakeLists.txt
@@ -6,6 +6,10 @@ cmake_minimum_required(VERSION 3.13)
 
 option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
 
+# tensorrt_provider_factory.h contains old APIs of the tensorrt execution provider
+
+CHECK_INCLUDE_FILE(tensorrt_provider_factory.h HAVE_TENSORRT_PROVIDER_FACTORY_H)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -15,4 +19,7 @@ include_directories(
 )
         
 ADD_EXECUTABLE(capi_test  main.cpp)
+if(HAVE_TENSORRT_PROVIDER_FACTORY_H)
+  target_compile_definitions(capi_test PRIVATE -DHAVE_TENSORRT_PROVIDER_FACTORY_H)
+endif()
 target_link_libraries(capi_test onnxruntime)

--- a/c_cxx/squeezenet/CMakeLists.txt
+++ b/c_cxx/squeezenet/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
 
 # tensorrt_provider_factory.h contains old APIs of the tensorrt execution provider
-
+include(CheckIncludeFiles)
 CHECK_INCLUDE_FILE(tensorrt_provider_factory.h HAVE_TENSORRT_PROVIDER_FACTORY_H)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/c_cxx/squeezenet/CMakeLists.txt
+++ b/c_cxx/squeezenet/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.13)
 option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
 
 # tensorrt_provider_factory.h contains old APIs of the tensorrt execution provider
-include(CheckIncludeFiles)
-CHECK_INCLUDE_FILE(tensorrt_provider_factory.h HAVE_TENSORRT_PROVIDER_FACTORY_H)
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE_CXX(tensorrt_provider_factory.h HAVE_TENSORRT_PROVIDER_FACTORY_H)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/c_cxx/squeezenet/main.cpp
+++ b/c_cxx/squeezenet/main.cpp
@@ -5,6 +5,8 @@
 #include <assert.h>
 #include <vector>
 #include <onnxruntime_cxx_api.h>
+
+#ifdef HAVE_TENSORRT_PROVIDER_FACTORY_H
 #include <tensorrt_provider_factory.h>
 #include <tensorrt_provider_options.h>
 
@@ -31,6 +33,7 @@ std::unique_ptr<OrtTensorRTProviderOptionsV2> get_default_trt_provider_options()
 
   return tensorrt_options;
 }
+#endif
 
 void run_ort_trt() {
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "test");

--- a/c_cxx/squeezenet/main.cpp
+++ b/c_cxx/squeezenet/main.cpp
@@ -99,8 +99,8 @@ void run_ort_trt() {
     // print input shapes/dims
     input_node_dims = tensor_info.GetShape();
     printf("Input %d : num_dims=%zu\n", i, input_node_dims.size());
-    for (int j = 0; j < input_node_dims.size(); j++)
-      printf("Input %d : dim %d=%jd\n", i, j, input_node_dims[j]);
+    for (size_t j = 0; j < input_node_dims.size(); j++)
+      printf("Input %d : dim %zu=%jd\n", i, j, input_node_dims[j]);
   }
 
   size_t input_tensor_size = 224 * 224 * 3;  // simplify ... using known dim values to calculate size


### PR DESCRIPTION
1. Add the squeezenet example to CI build
2. Validate all C/C++ examples with the latest onnxruntime nightly build. (Something is better than nothing)