### PR TITLE
Pin protobuf dependency (of ONNX) to specific version.

### DIFF
--- a/mobile/examples/basic_usage/model/requirements.txt
+++ b/mobile/examples/basic_usage/model/requirements.txt
@@ -1,2 +1,3 @@
 onnx==1.10.0
 onnxruntime==1.10.0
+protobuf==3.20.1

--- a/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.requirements.txt
+++ b/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.requirements.txt
@@ -1,4 +1,5 @@
 onnx==1.10.0
 onnxruntime==1.10.0
+protobuf==3.20.1
 tensorflow==2.6.3
 tf2onnx==1.9.3


### PR DESCRIPTION
ONNX 1.10 does not restrict the maximum version of its protobuf dependency and it doesn't work with the latest. Pin the protobuf version in the requirements files here.