### PR TITLE
Work around MAUI iOS publish issue

### DIFF
--- a/mobile/examples/Maui/MauiVisionSample/MauiVisionSample/MauiVisionSample.csproj
+++ b/mobile/examples/Maui/MauiVisionSample/MauiVisionSample/MauiVisionSample.csproj
@@ -26,7 +26,17 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
-
+	
+	<!-- 
+	Short term workaround for issue with publishing the iOS IPA by manually adding CoreML to the frameworks we link against.
+	https://github.com/microsoft/onnxruntime/issues/12420
+	-->
+	<Target Name="AddCoreML" Condition="'$(TargetFramework)' == 'net6.0-ios'" AfterTargets="_LoadLinkerOutput" BeforeTargets="_ComputeLinkNativeExecutableInputs">
+		<ItemGroup>
+			<_LinkerFrameworks Include="CoreML" />
+		</ItemGroup>
+	</Target>
+	
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -45,7 +55,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.12.0" />
+	  <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.12.1" />
 	  <PackageReference Include="SkiaSharp" Version="2.88.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Add short term workaround to issue with iOS publish where the CoreML frameworks is not added to the link list. Pending real fix from MAUI folks.

Also update ORT to 1.12.1 which has a better Android build.