### PR TITLE
Update protobuf version to be compatible with tensorflow requirement.

### DIFF
--- a/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.requirements.txt
+++ b/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.requirements.txt
@@ -1,5 +1,5 @@
 onnx==1.10.0
 onnxruntime==1.13.1
-protobuf==3.20.2
+protobuf==3.19.6
 tensorflow==2.9.3
 tf2onnx==1.9.3


### PR DESCRIPTION
"tensorflow 2.9.3 depends on protobuf<3.20 and >=3.9.2"
Picked a version less than 3.20.