### PR TITLE
Update ONNX to 1.13 due to security warning.

### DIFF
--- a/mobile/examples/basic_usage/model/requirements.txt
+++ b/mobile/examples/basic_usage/model/requirements.txt
@@ -1,3 +1,3 @@
-onnx==1.10.0
+onnx==1.13.0
 onnxruntime==1.13.1
 protobuf==3.20.2

--- a/mobile/examples/speech_recognition/model/requirements.txt
+++ b/mobile/examples/speech_recognition/model/requirements.txt
@@ -1,6 +1,6 @@
-onnx==1.10.0
+onnx==1.13.0
 onnxruntime==1.13.1
 protobuf==3.20.2
 torch==1.13.1
 torchaudio==0.13.1
-transformers==4.6.1
+transformers==4.26.1


### PR DESCRIPTION
Update ONNX to 1.13 due to security warning.

> Versions of the package onnx before 1.13.0 are vulnerable to Directory Traversal as the external_data field of the tensor proto can have a path to the file which is outside the model current directory or user-provided directory, for example "../../../etc/passwd"

Also update transformers to newer version that supports python 3.10. The existing version triggers and attempt to build the tokenizers python package dependency from source which requires the Rust compiler. Model generation was successful with the new version.