### PR TITLE
add squeezenet sample for qnn ep cpu backend

### DIFF
--- a/c_cxx/QNN_EP/CMakeLists.txt
+++ b/c_cxx/QNN_EP/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(qnn_ep_sample C CXX)
+
+set(CMAKE_BUILD_TYPE Release)
+
+cmake_minimum_required(VERSION 3.13)
+
+option(ONNXRUNTIME_ROOTDIR "onnxruntime root dir")
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(${ONNXRUNTIME_ROOTDIR}/include)
+        
+ADD_EXECUTABLE(qnn_ep_sample  main.cpp)
+target_link_libraries(qnn_ep_sample onnxruntime)

--- a/c_cxx/QNN_EP/README.md
+++ b/c_cxx/QNN_EP/README.md
@@ -1,0 +1,5 @@
+## How to run the application
+(Windows11/ARM64) Run ```run_qnn_ep_sample.bat``` with path to onnxruntime home directory and current onnxruntime-inference-examples\c_cxx\QNN_EP directory
+```
+.\run_qnn_ep_sample.bat D:\path\to\onnxruntime-win-arm64 D:\repos\onnxruntime-inference-examples\c_cxx\QNN_EP
+```

--- a/c_cxx/QNN_EP/main.cpp
+++ b/c_cxx/QNN_EP/main.cpp
@@ -1,0 +1,109 @@
+// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+//
+
+#include <assert.h>
+#include <onnxruntime_cxx_api.h>
+
+#include <iostream>
+#include <vector>
+
+void run_ort_qnn_cpu() {
+  Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "test");
+  const auto& api = Ort::GetApi();
+
+  Ort::SessionOptions session_options;
+  session_options.SetIntraOpNumThreads(1);
+
+  session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
+
+  const wchar_t* model_path = L"squeezenet.onnx";
+
+  std::vector<const char*> options_keys = {"backend_path"};
+  std::vector<const char*> options_values = {"QnnCpu.dll"};
+  Ort::ThrowOnError(api.SessionOptionsAppendExecutionProvider(session_options, "QNN", options_keys.data(),
+			                                      options_values.data(), options_keys.size()));
+  Ort::Session session(env, model_path, session_options);
+
+  // print model input layer (node names, types, shape etc.)
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  // print number of model input nodes
+  const size_t num_input_nodes = session.GetInputCount();
+  std::vector<Ort::AllocatedStringPtr> input_names_ptr;
+  std::vector<const char*> input_node_names;
+  input_names_ptr.reserve(num_input_nodes);
+  input_node_names.reserve(num_input_nodes);
+  std::vector<int64_t> input_node_dims;  // simplify... this model has only 1 input node {1, 3, 224, 224}.
+                                         // Otherwise need vector<vector<>>
+
+  std::cout << "Number of inputs = " << num_input_nodes << std::endl;
+
+  // iterate over all input nodes
+  for (size_t i = 0; i < num_input_nodes; i++) {
+    // print input node names
+    auto input_name = session.GetInputNameAllocated(i, allocator);
+    std::cout << "Input " << i << " : name =" << input_name.get() << std::endl;
+    input_node_names.push_back(input_name.get());
+    input_names_ptr.push_back(std::move(input_name));
+
+    // print input node types
+    auto type_info = session.GetInputTypeInfo(i);
+    auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+
+    ONNXTensorElementDataType type = tensor_info.GetElementType();
+    std::cout << "Input " << i << " : type = " << type << std::endl;
+
+    // print input shapes/dims
+    input_node_dims = tensor_info.GetShape();
+    std::cout << "Input " << i << " : num_dims = " << input_node_dims.size() << '\n';
+    for (size_t j = 0; j < input_node_dims.size(); j++) {
+      std::cout << "Input " << i << " : dim[" << j << "] =" << input_node_dims[j] << '\n';
+    }
+    std::cout << std::flush;
+  }
+
+  constexpr size_t input_tensor_size = 224 * 224 * 3;  // simplify ... using known dim values to calculate size
+                                                       // use OrtGetTensorShapeElementCount() to get official size!
+
+  std::vector<float> input_tensor_values(input_tensor_size);
+  std::vector<const char*> output_node_names = {"softmaxout_1"};
+
+  // initialize input data with values in [0.0, 1.0]
+  for (unsigned int i = 0; i < input_tensor_size; i++) input_tensor_values[i] = (float)i / (input_tensor_size + 1);
+
+  // create input tensor object from data values
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  auto input_tensor = Ort::Value::CreateTensor<float>(memory_info, input_tensor_values.data(), input_tensor_size,
+                                                            input_node_dims.data(), 4);
+  assert(input_tensor.IsTensor());
+
+  // score model & input tensor, get back output tensor
+  auto output_tensors =
+      session.Run(Ort::RunOptions{nullptr}, input_node_names.data(), &input_tensor, 1, output_node_names.data(), 1);
+  assert(output_tensors.size() == 1 && output_tensors.front().IsTensor());
+
+  // Get pointer to output tensor float values
+  float* floatarr = output_tensors.front().GetTensorMutableData<float>();
+  assert(abs(floatarr[0] - 0.000045) < 1e-6);
+
+  // score the model, and print scores for first 5 classes
+  for (int i = 0; i < 5; i++) {
+    std::cout << "Score for class [" << i << "] =  " << floatarr[i] << '\n';
+  }
+  std::cout << std::flush;
+
+  // Results should be as below...
+  // Score for class[0] = 0.000045
+  // Score for class[1] = 0.003846
+  // Score for class[2] = 0.000125
+  // Score for class[3] = 0.001180
+  // Score for class[4] = 0.001317
+
+  std::cout << "Done!" << std::endl;
+}
+
+int main(int /*argc*/, char*[]) {
+  run_ort_qnn_cpu();
+  return 0;
+}

--- a/c_cxx/QNN_EP/run_qnn_ep_sample.bat
+++ b/c_cxx/QNN_EP/run_qnn_ep_sample.bat
@@ -1,0 +1,22 @@
+set ONNX_MODEL_URL="https://media.githubusercontent.com/media/onnx/models/main/vision/classification/squeezenet/model/squeezenet1.0-7.onnx"
+set ONNX_MODEL="squeezenet.onnx"
+SET ORT_ROOT=%1
+SET WORKSPACE=%2
+
+set ORT_LIB=%ORT_ROOT%\lib
+echo %ORT_LIB%
+
+cd %WORKSPACE%
+REM build with Visual Studios 2022 ARM 64-bit Native
+cmake.exe -S . -B build\ -G "Visual Studio 17 2022" -DONNXRUNTIME_ROOTDIR=%ORT_ROOT%
+
+REM Copy ORT libraries for linker to build.
+cd build
+powershell -Command "cp %ORT_LIB%\* ."
+MSBuild.exe .\qnn_ep_sample.sln /property:Configuration=Release
+
+REM Copy ORT libraries for executable to run.
+cd Release
+powershell -Command "cp %ORT_LIB%\* ."
+powershell -Command "Invoke-WebRequest %ONNX_MODEL_URL% -Outfile %ONNX_MODEL%"
+qnn_ep_sample.exe


### PR DESCRIPTION
add a simple squeezenet example for QNN EP (cpu backend)
built and tested with Visual Studio 2022 ARM64 and QNN 2.8 for Win/ARM. 