### PR TITLE
Add a VC++ static analysis Github workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - snnn/p2
   pull_request:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - snnn/p3
   pull_request:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
           &${{ github.workspace }}\ci_build\download_ort_release 1.14.1
 
       - name: Config cmake
-        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_C_FLAGS="/analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -DCMAKE_CXX_FLAGS="/EHsc /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
+        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_C_FLAGS="/MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -DCMAKE_CXX_FLAGS="/EHsc /MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
 
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - snnn/p2
   pull_request:
 
 concurrency:
@@ -32,7 +31,7 @@ jobs:
           &${{ github.workspace }}\ci_build\download_ort_release 1.14.1
 
       - name: Config cmake
-        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_CXX_FLAGS="/analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
+        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_C_FLAGS="/analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -DCMAKE_CXX_FLAGS="/EHsc /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
 
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - snnn/p2
+      - snnn/p3
   pull_request:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,42 @@
+name: Windows_CI
+on:
+  push:
+    branches:
+      - main
+      - snnn/p2
+  pull_request:
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  Onnxruntime-SCA:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.11.x'
+          architecture: 'x64'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Download ORT
+        shell: powershell
+        run: |
+          &${{ github.workspace }}\ci_build\download_ort_release 1.14.1
+
+      - name: Config cmake
+        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_CXX_FLAGS="/analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:logoutput.sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
+
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true
+        with:
+          sarif_file: ${{ github.workspace }}\output\MergeResult.sarif
+          category: VS_SCA

--- a/c_cxx/CMakeLists.txt
+++ b/c_cxx/CMakeLists.txt
@@ -97,5 +97,4 @@ add_subdirectory(squeezenet)
 if(WIN32 OR PNG_FOUND)
   add_subdirectory(fns_candy_style_transfer)
 endif()
-#missing experimental_onnxruntime_cxx_api.h
-#add_subdirectory(model-explorer)
+add_subdirectory(model-explorer)

--- a/c_cxx/fns_candy_style_transfer/image_file_wic.cc
+++ b/c_cxx/fns_candy_style_transfer/image_file_wic.cc
@@ -5,9 +5,10 @@
 
 #include <filesystem>
 #include <vector>
+#include <wil/com.h>
 
 #include "image_file.h"
-#include "wil/com.h"
+
 
 /**
  *  Read the file from `input_file` and auto-scale it to 720x720

--- a/c_cxx/imagenet/image_loader.cc
+++ b/c_cxx/imagenet/image_loader.cc
@@ -77,9 +77,9 @@ void ResizeImageInMemory(const T* input_data, float* output_data, int in_height,
     xs[i].upper *= channels;
   }
 
-  const int64_t in_row_size = in_width * channels;
-  const int64_t in_batch_num_values = in_height * in_row_size;
-  const int64_t out_row_size = out_width * channels;
+  const int64_t in_row_size = static_cast<int64_t>(in_width) * channels;
+  const int64_t in_batch_num_values = static_cast<int64_t>(in_height) * in_row_size;
+  const int64_t out_row_size = static_cast<int64_t>(out_width) * channels;
 
   const T* input_b_ptr = input_data;
   float* output_y_ptr = output_data;

--- a/c_cxx/imagenet/image_loader_wic.cc
+++ b/c_cxx/imagenet/image_loader_wic.cc
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "image_loader.h"
-#include <sstream>
+#include <atlbase.h>
 #include <wincodec.h>
 #include <wincodecsdk.h>
-#include <atlbase.h>
+
+#include <sstream>
+
+#include "image_loader.h"
 
 bool CreateImageLoader(void** out) {
   IWICImagingFactory* piFactory;
@@ -82,7 +84,7 @@ OrtStatus* LoadImageFromFileAndCrop(void* loader, const ORTCHAR_T* filename, dou
     rect.Width = bbox_w_size;
 
     ATLENSURE_SUCCEEDED(ppIFormatConverter->CopyPixels(&rect, stride, static_cast<UINT>(data.size()), data.data()));
-    float* float_file_data = (float*)malloc(data.size() * sizeof(float));
+    float* float_file_data = new float[data.size()];
     size_t len = data.size();
     for (size_t i = 0; i != len; ++i) {
       float_file_data[i] = static_cast<float>(data[i]) / 255;

--- a/c_cxx/model-explorer/CMakeLists.txt
+++ b/c_cxx/model-explorer/CMakeLists.txt
@@ -4,5 +4,6 @@
 add_executable(model-explorer model-explorer.cpp)
 target_link_libraries(model-explorer PRIVATE onnxruntime)
 
-add_executable(batch-model-explorer batch-model-explorer.cpp)
-target_link_libraries(batch-model-explorer PRIVATE onnxruntime)
+#TODO: fix the build error
+#add_executable(batch-model-explorer batch-model-explorer.cpp)
+#target_link_libraries(batch-model-explorer PRIVATE onnxruntime)

--- a/c_cxx/model-explorer/model-explorer.cpp
+++ b/c_cxx/model-explorer/model-explorer.cpp
@@ -53,19 +53,17 @@ Ort::Value vec_to_tensor(std::vector<T>& data, const std::vector<std::int64_t>& 
   return tensor;
 }
 
-int main(int argc, char** argv) {
+#ifdef _WIN32
+int wmain(int argc, ORTCHAR_T* argv[]) {
+#else
+int main(int argc, ORTCHAR_T* argv[]) {
+#endif
   if (argc != 2) {
     std::cout << "Usage: ./onnx-api-example <onnx_model.onnx>" << std::endl;
     return -1;
   }
 
-#ifdef _WIN32
-  std::string str = argv[1];
-  std::wstring wide_string = std::wstring(str.begin(), str.end());
-  std::basic_string<ORTCHAR_T> model_file = std::basic_string<ORTCHAR_T>(wide_string);
-#else
-  std::string model_file = argv[1];
-#endif
+  std::basic_string<ORTCHAR_T> model_file = argv[1];
 
   // onnxruntime setup
   Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "example-model-explorer");


### PR DESCRIPTION
Compare to the ADO pipelines we already have, this one can directly publish scan results to Github website for view. It will be better integrated with Github UI. 

Example output:

![image](https://user-images.githubusercontent.com/856316/235329291-b81e1346-51f7-4c8b-a0d0-90ebc266254a.png)
