### PR TITLE
Object detection: work with Unix line endings in classes.txt file.

### DIFF
--- a/mobile/examples/object_detection/android/app/src/main/java/ai/onnxruntime/example/objectdetection/MainActivity.kt
+++ b/mobile/examples/object_detection/android/app/src/main/java/ai/onnxruntime/example/objectdetection/MainActivity.kt
@@ -99,9 +99,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun readClasses(): List<String> {
-        val classes_id = R.raw.classes
-        val classes_bytes = resources.openRawResource(classes_id).readBytes()
-        return String(classes_bytes).split("\r\n".toRegex())
+        return resources.openRawResource(R.raw.classes).bufferedReader().readLines()
     }
 
     private fun readInputImage(): InputStream {


### PR DESCRIPTION
When checked out on Linux the classes.txt assets file only has \n as line endings so that is how it gets packaged into the app. This change makes the splitting of that file work with such line endings too otherwise there will be a single long classification label instead of 80.