### PR TITLE
Add accuracy evaluation example

### DIFF
--- a/quantization/language_model/evaluation/README.md
+++ b/quantization/language_model/evaluation/README.md
@@ -1,0 +1,50 @@
+# Evaluating the Accuracy of ORT Causal Latent Language Models (LLMs)
+
+This folder contains an implementation example to evaluate the accuracy of ONNX LLMs. Evaluations are based on benchmarks from the [Eleuther AI Language Model Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness), a unified framework to test generative language models on a large number of different evaluation tasks.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+- [Evaluation Metrics](#evaluation-metrics)
+- [Tasks](#tasks)
+
+## Getting Started
+
+To get started with the evaluation, follow these steps:
+
+1. Clone the repository
+2. Navigate to the parent folder and install the required dependencies: 
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Prepare ONNX model using optimum-cli:
+   ```bash
+   optimum-cli export onnx --model decapoda-research/llama-7b-hf --task causal-lm-past llama-7b-onnx   
+   ```
+
+## Usage
+
+Evaluate ONNX Causal model:
+   ```bash
+   python main.py --model_args pretrained=llama-7b-onnx \
+                  --device cpu \
+                  --tasks hendrycksTest-marketing,lambada_openai,arc_easy
+   ```
+
+Additional arguments can be provided to the model constructor using the `--model_args` flag.
+
+## Evaluation Metrics
+
+During the evaluation, the following metrics can measured:
+
+- **Accuracy**: The proportion of correct predictions over the total number of samples.
+
+- **Perplexity**: Calculated based on the probability distribution assigned by the model to each token in a sequence. The lower the perplexity value, the better the language model's performance.
+
+## Tasks
+
+Available tasks to run can be found in the [lm-evaluation-harness tool](https://github.com/EleutherAI/lm-evaluation-harness/blob/4fbbd60fa3573dcbf61eb79492f772adeb969157/lm_eval/tasks/__init__.py#L99) hosted by EleutherAI
+
+
+

--- a/quantization/language_model/evaluation/README.md
+++ b/quantization/language_model/evaluation/README.md
@@ -1,6 +1,6 @@
-# Evaluating the Accuracy of ORT Causal Latent Language Models (LLMs)
+# Evaluating the Accuracy of ORT Causal Large Language Models (LLMs)
 
-This folder contains an implementation example to evaluate the accuracy of ONNX LLMs. Evaluations are based on benchmarks from the [Eleuther AI Language Model Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness), a unified framework to test generative language models on a large number of different evaluation tasks.
+This folder contains an implementation example to evaluate the accuracy of ORT LLMs. Evaluations are based on benchmarks from the [Eleuther AI Language Model Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness), a unified framework to test generative language models on a large number of different evaluation tasks.
 
 ## Table of Contents
 

--- a/quantization/language_model/evaluation/README.md
+++ b/quantization/language_model/evaluation/README.md
@@ -20,7 +20,7 @@ To get started with the evaluation, follow these steps:
    ```
 3. Prepare ONNX model using optimum-cli:
    ```bash
-   optimum-cli export onnx --model decapoda-research/llama-7b-hf --task causal-lm-past llama-7b-onnx   
+   optimum-cli export onnx --model decapoda-research/llama-7b-hf --task causal-lm-with-past --for-ort --device cpu llama-7b-onnx   
    ```
 
 ## Usage

--- a/quantization/language_model/evaluation/main.py
+++ b/quantization/language_model/evaluation/main.py
@@ -1,0 +1,137 @@
+import os
+import json
+import logging
+import argparse
+from lm_eval import utils, tasks, evaluator, base
+
+from ort_lm import ORTCausalLM
+
+
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
+                    datefmt = '%m/%d/%Y %H:%M:%S',
+                    level = logging.WARN)
+
+def parse_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--model_args',
+        type=str,
+        help="Folder path of pre-trained onnx model and additional arguments. E.g pretrained=llama-2-7b-onnx.py"
+    )
+    parser.add_argument(
+        '--batch_size',
+        default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--tasks", help="tasks list for accuracy validation"
+    )
+    parser.add_argument("--provide_description", action="store_true")
+    parser.add_argument("--num_fewshot", type=int, default=0)
+    parser.add_argument("--max_batch_size", type=int, default=None,
+                        help="Maximal batch size to try with --batch_size auto")
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--output_path", default=None)
+    parser.add_argument("--limit", type=float, default=None,
+                        help="Limit the number of examples per task. "
+                             "If <1, limit is a percentage of the total number of examples.")
+    parser.add_argument("--no_cache", action="store_true")
+    parser.add_argument("--decontamination_ngrams_path", default=None)
+    parser.add_argument("--description_dict_path", default=None)
+    parser.add_argument("--check_integrity", action="store_true")
+    parser.add_argument("--write_out", action="store_true", default=False)
+    parser.add_argument("--output_base_path", type=str, default=None)
+    return parser.parse_args()
+
+
+def main(args):
+    model = "ort-causal"
+    if args.tasks:
+        task_names = utils.pattern_match(args.tasks.split(","), tasks.ALL_TASKS)
+    else:
+        task_names = tasks.ALL_TASKS
+
+    print(f"Selected Tasks: {task_names}")
+
+    description_dict = {}
+    if args.description_dict_path:
+        with open(args.description_dict_path, "r") as f:
+            description_dict = json.load(f)
+
+    additional_config = {"batch_size": args.batch_size, "max_batch_size": args.max_batch_size, "device": args.device}
+    model_args = utils.simple_parse_args_string(args.model_args)
+    model_args2 = {k: v for k, v in additional_config.items() if v is not None}
+
+
+    lm_model = ORTCausalLM(
+        **model_args,
+        **model_args2
+        )
+    
+    if not args.no_cache:
+        lm_model = base.CachingLM(
+            lm_model,
+            "lm_cache/"
+            + (model if isinstance(model, str) else model.model.config._name_or_path)
+            + "_"
+            + args.model_args.replace("=", "-").replace(",", "_").replace("/", "-")
+            + ".db",
+        )
+
+    task_dict = tasks.get_task_dict(task_names)
+
+    if args.check_integrity:
+        utils.run_task_tests(task_list=tasks)
+
+    results = evaluator.evaluate(
+        lm=lm_model,
+        task_dict=task_dict,
+        num_fewshot=args.num_fewshot,
+        limit=args.limit,
+        bootstrap_iters=10000,
+        description_dict=description_dict,
+        decontamination_ngrams_path=args.decontamination_ngrams_path,
+        write_out=args.write_out,
+        output_base_path=args.output_base_path,
+    )
+
+    # add info about the model and few shot config
+    model_name = None
+    if isinstance(model, str):
+        model_name = model
+    results["config"] = {
+        "model": model_name,
+        "model_args": args.model_args,
+        "num_fewshot": args.num_fewshot,
+        "batch_size": args.batch_size,
+        "batch_sizes": list(lm_model.batch_sizes.values()) if hasattr(lm_model, "batch_sizes") else [],
+        "device": args.device,
+        "no_cache": args.no_cache,
+        "limit": args.limit,
+        "bootstrap_iters": 10000,
+        "description_dict": description_dict,
+    }
+
+    dumped = json.dumps(results, indent=2)
+    print(dumped)
+
+    if args.output_path:
+        os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
+        with open(args.output_path, "w") as f:
+            f.write(dumped)
+
+    batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))
+    print(
+        f"{model} ({args.model_args}), limit: {args.limit}, provide_description: {args.provide_description}, "
+        f"num_fewshot: {args.num_fewshot}, batch_size: {args.batch_size}{f' ({batch_sizes})' if batch_sizes else ''}"
+    )
+    print(evaluator.make_table(results))
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)
+

--- a/quantization/language_model/evaluation/ort_lm.py
+++ b/quantization/language_model/evaluation/ort_lm.py
@@ -1,0 +1,209 @@
+import torch
+from transformers import AutoTokenizer, BatchEncoding, PreTrainedTokenizerBase, AutoConfig
+from typing import List, Optional, Union
+from optimum.onnxruntime import ORTModelForCausalLM
+
+from lm_eval import utils
+from lm_eval.base import BaseLM
+
+TokenSequence = Union[List[int], torch.LongTensor, torch.Tensor, BatchEncoding]
+
+
+class ORTCausalLM(BaseLM):
+    _DEFAULT_MAX_LENGTH: int = 2048
+
+    def __init__(self,
+        pretrained: str,
+        tokenizer: Optional[str] = None,
+        subfolder: Optional[str] = None,
+        revision: Optional[str] = "main",
+        batch_size: Optional[Union[int, str]] = 1,
+        max_gen_toks: Optional[int] = 1024,
+        max_length: Optional[int] = None,
+        add_special_tokens: Optional[bool] = None,
+        device: Optional[Union[int, str]] = "cpu",
+        load_in_8bit: Optional[bool] = False,
+        trust_remote_code: Optional[bool] = False,
+        **kwargs,
+        ):
+        """Initializes an ORT `CausalModel` and huggingface `AutoTokenizer` for evaluation.
+        Args:
+            pretrained (str):
+                The Path to the ONNX model to be loaded. This is effectively the 
+                `pretrained_model_name_or_path` argument of `from_pretrained` in the 
+                optimum `onnxruntime` API.
+            add_special_tokens (bool, optional, defaults to True):
+                Whether to add special tokens to the input sequences. If `None`, the
+                default value will be set to `True` for seq2seq models (e.g. T5) and
+                `False` for causal models.
+                WARNING: Evaluating causal models with `add_special_tokens=True` is
+                currently __not__ supported.
+            load_in_8bit (bool, optional, defaults to False):
+                If True, will convert the loaded model into mixed-8bit quantized model. See:
+                https://huggingface.co/docs/transformers/main/en/main_classes/model#transformers.PreTrainedModel.from_pretrained.load_in_8bit
+            trust_remote_code (bool, optional, defaults to False):
+                If True, will trust the remote code when loading the model.
+        """
+        super().__init__()
+
+        assert isinstance(pretrained, str)
+        assert isinstance(device, str)
+        assert isinstance(batch_size, (int, str))
+        if (
+            add_special_tokens is not None
+        ):
+            # TODO: Support evaluating causal models with special tokens. Currently,
+            #  this is not possible because the `_loglikelihood_tokens()` method for
+            #  causal LMs makes a no-special-tokens assumption given that contexts
+            #  and labels/continuations are tokenized separately without special
+            #  tokens, concatenated, and then processed as inputs.
+            assert (
+                not add_special_tokens
+            ), "Evaluating causal models with `add_special_tokens=True` is currently not supported."
+
+        device_list = set(
+            ["cuda", "cpu"] + [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+        )
+        if device and device in device_list:
+            self._device = torch.device(device)
+            print(f"Using device '{device}'")
+        else:
+            print("Device not specified")
+            print(f"Cuda Available? {torch.cuda.is_available()}")
+            self._device = (
+                torch.device("cuda")
+                if torch.cuda.is_available()
+                else torch.device("cpu")
+            )
+        # setup for automatic batch size detection
+        if batch_size == "auto":
+            self._batch_size = batch_size
+        else:
+            self._batch_size = int(batch_size)
+        
+        self._max_gen_toks = max_gen_toks
+        self._max_length = max_length
+        self._add_special_tokens = add_special_tokens
+        model_kwargs = {"load_in_8bit": load_in_8bit}
+        self._config = AutoConfig.from_pretrained(pretrained)
+        self.model: ORTModelForCausalLM = ORTModelForCausalLM.from_pretrained(
+            pretrained,
+            revision=revision,
+            subfolder='' if subfolder is None else subfolder,
+            trust_remote_code=trust_remote_code,
+            config=self._config,
+            **kwargs,
+            **model_kwargs,
+            )
+        try:
+            self.tokenizer: PreTrainedTokenizerBase = self.model.preprocessors[0]
+        except IndexError:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                pretrained if tokenizer is None else tokenizer,
+                revision=revision + ("/" + subfolder if subfolder is not None else ""),
+                )
+        self.tokenizer.model_max_length = self.max_length
+        self._padding = self.tokenizer.pad_token is not None
+
+        torch.set_grad_enabled(False)
+
+    @property
+    def add_special_tokens(self) -> bool:
+        """Whether to include special tokens in encoded text. This should be
+        determined by whether or not the model was trained with special tokens.
+        TODO: Remove these conditionals once HuggingFace supports a way to
+         check whether or not an arbitrary model was trained with special tokens.
+        """
+        if self._add_special_tokens is not None:
+            return self._add_special_tokens
+        else:
+            return False
+
+    @property
+    def eot_token(self) -> str:
+        return self.tokenizer.eos_token
+
+    @property
+    def eot_token_id(self) -> int:
+        return self.tokenizer.eos_token_id
+
+    @property
+    def max_gen_toks(self) -> int:
+        return self._max_gen_toks
+
+    @property
+    def max_length(self) -> int:
+        """Return the maximum sequence length of the model.
+        NOTE: For relative position encoded models you should specify the max
+        sequence length of the model in the constructor via `max_length`.
+        """
+        if self._max_length is not None:
+            return self._max_length
+        # Try to get the sequence length from the model config.
+        seqlen_config_attrs = ("n_positions", "max_position_embeddings", "n_ctx", "max_sequence_length")
+        for attr in seqlen_config_attrs:
+            if self._config and hasattr(self._config, attr):
+                return getattr(self._config, attr)
+        if hasattr(self.tokenizer, "model_max_length"):
+            if self.tokenizer.model_max_length == 1000000000000000019884624838656:
+                return self._DEFAULT_MAX_LENGTH
+            return self.tokenizer.model_max_length
+        return self._DEFAULT_MAX_LENGTH
+
+    @property
+    def batch_size(self) -> int:
+        # TODO: Add adaptive batch size.
+        return self._batch_size  # * gpus
+
+    @property
+    def device(self) -> Union[int, str, torch.device]:
+        return self._device
+    
+    def _model_call(self, inputs: TokenSequence) -> TokenSequence:    
+        attention_mask = torch.ones(inputs.shape, dtype=torch.int64, device=self._device)
+        with torch.no_grad():
+            logits = self.model(inputs, attention_mask)["logits"]
+            return logits
+
+    def _model_generate(
+        self,
+        inputs: BatchEncoding,
+        max_tokens: int,
+        eos_token_id: int,
+    ) -> TokenSequence:
+        # Ensure that the context does not encroach into the `space`
+        # for the generation.
+        inputs["input_ids"] = inputs["input_ids"][:, self.max_gen_toks - self.max_length :]
+        inputs["attention_mask"] = inputs["attention_mask"][
+            :, self.max_gen_toks - self.max_length :
+        ]
+
+        generation_kwargs = {"do_sample": False, "max_length": max_tokens}
+        if eos_token_id is not None:
+            generation_kwargs['eos_token_id'] = eos_token_id
+            generation_kwargs['pad_token_id'] = eos_token_id # setting eos_token_id as pad token
+        
+        generations = self.model.generate(
+            **inputs,
+            **generation_kwargs,
+        )
+        return utils.select_continuation_from_batch_left_padding(
+            generations, max_context_size=inputs["input_ids"].size(1)
+        )
+    
+    def tok_encode(self, string: str) -> TokenSequence:
+        return self.tokenizer.encode(string, add_special_tokens=False)
+
+    def tok_encode_batch(self, strings: Union[str, List[str], List[List[str]]]) -> TokenSequence:
+        inputs = self.tokenizer(
+            strings,
+            padding=self._padding,
+            add_special_tokens=self.add_special_tokens,
+            return_tensors="pt",
+            return_token_type_ids=False,
+        )
+
+        return inputs
+
+    def tok_decode(self, tokens: torch.LongTensor) -> List[str]:
+        return self.tokenizer.batch_decode(tokens, skip_special_tokens=True)

--- a/quantization/language_model/evaluation/requirements.txt
+++ b/quantization/language_model/evaluation/requirements.txt
@@ -1,0 +1,8 @@
+git+https://github.com/EleutherAI/lm-evaluation-harness.git
+torch
+transformers
+accelerate
+onnx
+onnxruntime
+onnxruntime-extensions; python_version < '3.10'
+optimum


### PR DESCRIPTION
Adding accuracy evaluation example for evaluating ORT causal LLMs using the Eleuther AI Language Model Evaluation Harness.

Please be aware that when preparing the environment, there is no requirement to clone the lm-evaluation-harness repository for evaluation purposes.