### PR TITLE
Update LLaMA E2E notebook

### DIFF
--- a/python/models/llama_e2e.ipynb
+++ b/python/models/llama_e2e.ipynb
@@ -1148,6 +1148,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also pick up an already exported + optimized ONNX model from [Microsoft's repository](https://github.com/microsoft/Llama-2-Onnx/tree/main-CUDA_CPU)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Run LLaMA-2 End-to-End\n",
     "\n",
     "Now that the model is exported to ONNX, you can run it end-to-end. For this example, you can use the LLaMA-2 7B FP16 CUDA model with GQA.\n",
@@ -1164,8 +1171,7 @@
     "from transformers import LlamaConfig, LlamaTokenizer\n",
     "import numpy as np\n",
     "import onnxruntime as ort\n",
-    "import torch\n",
-    "import time"
+    "import torch"
    ]
   },
   {


### PR DESCRIPTION
This PR adds a link to the already exported + optimized ONNX models in the [Microsoft repository](https://github.com/microsoft/Llama-2-Onnx/tree/main-CUDA_CPU).