### PR TITLE
Use local models

### DIFF
--- a/c_cxx/squeezenet/run_capi_application.bat
+++ b/c_cxx/squeezenet/run_capi_application.bat
@@ -25,5 +25,10 @@ for /f "tokens=*" %%a in ('"C:\\Program Files (x86)\\Microsoft Visual Studio\\In
 REM Copy ORT libraries to same folder for executable to run.
 cd Release
 powershell -Command "cp %ORT_LIB%\* ."
-powershell -Command "Invoke-WebRequest %ONNX_MODEL_URL% -Outfile %ONNX_MODEL%"
+if exist "C:\local\models\opset8\test_squeezenet\model.onnx" (
+    echo "Using local model"
+    powershell -Command "cp C:\local\models\opset8\test_squeezenet\model.onnx %ONNX_MODEL%"
+) else (
+    powershell -Command "Invoke-WebRequest %ONNX_MODEL_URL% -Outfile %ONNX_MODEL%"
+)
 capi_test.exe


### PR DESCRIPTION
The URL isn't available now.
Use local model like the .sh script to fix Nuget pipeline exception.