### PR TITLE
Fix typo

### DIFF
--- a/js/quick-start_onnxruntime-node-bundler/README.md
+++ b/js/quick-start_onnxruntime-node-bundler/README.md
@@ -17,10 +17,10 @@ When using webpack on nodejs modules it is not common to include modules like on
    ```sh
    npm run build
    ```
-   this generates the bundle file `./dist/main.js`
+   this generates the bundle file `./dist/bundle.min.js`
 
 3. run with
    ```sh
-   node dist/main.js
+   node dist/bundle.min.js
    ```
    


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime-inference-examples/blob/c2e96a8de5d5cf4fdf845b5f8977980d64bc1a8e/js/quick-start_onnxruntime-node-bundler/webpack.config.js#L16-L19

The above code creates a `bundle.min.js` file in the `dist` directory.

https://github.com/microsoft/onnxruntime-inference-examples/blob/c2e96a8de5d5cf4fdf845b5f8977980d64bc1a8e/js/quick-start_onnxruntime-node-bundler/README.md?plain=1#L16-L25

However, in `README.md` it says that it creates a bundle file `./dist/main.js` and runs it through `node dist/main.js`.

 This seems to be a typo, so I changed `dist/main.js` to `./dist/bundle.min.js`.

```sh
hs@hs-OMEN:~/forks/onnxruntime-inference-examples/js/quick-start_onnxruntime-node-bundler$ npm install

added 151 packages, and audited 152 packages in 1s

23 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
```sh
hs@hs-OMEN:~/forks/onnxruntime-inference-examples/js/quick-start_onnxruntime-node-bundler$ npm run build

> quick-start_onnxruntime-web-bundler@1.0.0 build
> webpack --config ./webpack.config.js --mode production

asset bundle.min.js 626 bytes [emitted] [minimized] (name: main)
asset model.onnx 120 bytes [emitted] [from: model.onnx] [copied]
./main.js 1.12 KiB [built] [code generated]
external "onnxruntime-node" 42 bytes [built] [code generated]
webpack 5.91.0 compiled successfully in 157 ms
```
Running node `dist/main.js` generates an error.
```sh
hs@hs-OMEN:~/forks/onnxruntime-inference-examples/js/quick-start_onnxruntime-node-bundler$ node dist/main.js
node:internal/modules/cjs/loader:1031
  throw err;
  ^

Error: Cannot find module '/home/hs/forks/onnxruntime-inference-examples/js/quick-start_onnxruntime-node-bundler/dist/main.js'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1028:15)
    at Function.Module._load (node:internal/modules/cjs/loader:873:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```
`node dist/bundle.min.js` executes successfully.
```sh
hs@hs-OMEN:~/forks/onnxruntime-inference-examples/js/quick-start_onnxruntime-node-bundler$ node dist/bundle.min.js
data of result tensor 'c': 700,800,900,1580,1840,2100,2460,2880,3300
```