### PR TITLE
Remove Q & DQ since Onnx wrapper model has them already

### DIFF
--- a/c_cxx/QNN_EP/mobilenetv2_classification/run_qnn_ep_sample.bat
+++ b/c_cxx/QNN_EP/mobilenetv2_classification/run_qnn_ep_sample.bat
@@ -156,9 +156,11 @@ IF EXIST mobilenetv2-12_quant_shape.onnx_ctx.onnx (
 REM run mobilenetv2-12_net_qnn_ctx.onnx (generated from native QNN) with QNN HTP backend
 qnn_ep_sample.exe --qnn mobilenetv2-12_net_qnn_ctx.onnx kitten_input_nhwc.raw
 
+REM only works for v73 and higher
 REM run mobilenetv2-12_shape.onnx (float32 model) with QNN HTP backend with FP16 precision
 qnn_ep_sample.exe --fp32 mobilenetv2-12_shape.onnx kitten_input.raw
 
+REM only works for v73 and higher
 REM run mobilenetv2-12_shape_fp16.onnx (float16 model with float32 IO) with QNN HTP backend 
 qnn_ep_sample.exe --fp16 mobilenetv2-12_shape_fp16.onnx kitten_input.raw
 


### PR DESCRIPTION
Update according to Ort PR https://github.com/microsoft/onnxruntime/pull/20107

The wrapper Onnx model generated from native QNN context binary already have Q, DQ nodes if the inputs/outputs are quantized data. So the example application doesn't need to quantize inputs and dequantize the outputs any more.