### PR TITLE
Fix mobile examples CI pipeline

### DIFF
--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -46,8 +46,6 @@ stages:
     pool:
       vmImage: "macOS-12"
 
-    dependsOn: ProcessParameters
-
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -56,11 +56,9 @@ stages:
 
     strategy:
       matrix:
-        full:
-          OrtPodNamePrefix: onnxruntime
+        onnx_model:
           XcodeArgs: 'GCC_PREPROCESSOR_DEFINITIONS="$GCC_PREPROCESSOR_DEFINITIONS ORT_BASIC_USAGE_USE_ONNX_FORMAT_MODEL"'
-        mobile:
-          OrtPodNamePrefix: onnxruntime-mobile
+        ort_format_model:
           XcodeArgs: ''
 
     steps:
@@ -73,12 +71,10 @@ stages:
       workingDirectory: mobile/examples/basic_usage/ios
       displayName: "Generate model"
 
-    - bash: |
-        set -e
-        PODFILE=mobile/examples/basic_usage/ios/Podfile
-        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-        cat ${PODFILE}
-      displayName: "Update Podfile"
+    - template: templates/update-podfile-step.yml
+      parameters:
+        podfilePath: 'mobile/examples/basic_usage/ios/Podfile'
+        ortPodVersionSpecifier: $(OrtPodVersionSpecifier)
 
     - script: pod install
       workingDirectory: 'mobile/examples/basic_usage/ios'
@@ -147,13 +143,6 @@ stages:
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 
-    strategy:
-      matrix:
-        full:
-          OrtPodNamePrefix: onnxruntime
-        mobile:
-          OrtPodNamePrefix: onnxruntime-mobile
-
     steps:
     - template: templates/use-python-step.yml
 
@@ -164,12 +153,10 @@ stages:
       workingDirectory: mobile/examples/speech_recognition/ios
       displayName: "Generate model"
 
-    - bash: |
-        set -e
-        PODFILE=mobile/examples/speech_recognition/ios/Podfile
-        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-        cat ${PODFILE}
-      displayName: "Update Podfile"
+    - template: templates/update-podfile-step.yml
+      parameters:
+        podfilePath: 'mobile/examples/basic_usage/ios/Podfile'
+        ortPodVersionSpecifier: $(OrtPodVersionSpecifier)
 
     - script: pod install
       workingDirectory: 'mobile/examples/speech_recognition/ios'
@@ -191,13 +178,6 @@ stages:
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 
-    strategy:
-      matrix:
-        full:
-          OrtPodNamePrefix: onnxruntime
-        mobile:
-          OrtPodNamePrefix: onnxruntime-mobile
-
     steps:
     - template: templates/use-python-step.yml
 
@@ -208,12 +188,10 @@ stages:
       workingDirectory: mobile/examples/object_detection/ios/ORTObjectDetection
       displayName: "Generate model"
 
-    - bash: |
-        set -e
-        PODFILE=mobile/examples/object_detection/ios/Podfile
-        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-        cat ${PODFILE}
-      displayName: "Update Podfile"
+    - template: templates/update-podfile-step.yml
+      parameters:
+        podfilePath: 'mobile/examples/basic_usage/ios/Podfile'
+        ortPodVersionSpecifier: $(OrtPodVersionSpecifier)
 
     - script: pod install
       workingDirectory: 'mobile/examples/object_detection/ios'
@@ -272,11 +250,9 @@ stages:
 
     strategy:
       matrix:
-        full:
-          OrtPackageName: onnxruntime-android
+        onnx_model:
           ModelFormat: onnx
-        mobile:
-          OrtPackageName: onnxruntime-mobile
+        ort_format_model:
           ModelFormat: ort
 
     steps:
@@ -290,15 +266,6 @@ stages:
         ./prepare_models.py --output_dir ./app/src/main/res/raw --format $(ModelFormat)
       workingDirectory: mobile/examples/image_classification/android
       displayName: "Generate models"
-
-    - bash: |
-        set -e
-        GRADLE_FILE=mobile/examples/image_classification/android/app/build.gradle
-        sed -i "" \
-          -e "s/implementation 'com.microsoft.onnxruntime:onnxruntime-android:latest.release'/implementation 'com.microsoft.onnxruntime:$(OrtPackageName):latest.release'/" \
-          ${GRADLE_FILE}
-        cat ${GRADLE_FILE}
-      displayName: "Update build.gradle"
 
     - template: templates/run-with-android-emulator-steps.yml
       parameters:

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -4,13 +4,18 @@ parameters:
   type: string
   default: "default"
 
+variables:
+  - name: AndroidTestAgentPool
+    value: "onnxruntime-Ubuntu2204-AMD-CPU"
+  - name: IosTestAgentVmImage
+    value: "macOS-12"
+
 stages:
 - stage: ProcessParameters
   dependsOn: []
   jobs:
   - job: j
-    pool:
-      vmImage: "ubuntu-20.04"
+    pool: "onnxruntime-Ubuntu2204-AMD-CPU"
 
     steps:
     - checkout: none
@@ -44,7 +49,7 @@ stages:
   jobs:
   - job: j
     pool:
-      vmImage: "macOS-12"
+      vmImage: ${{ variables.IosTestAgentVmImage }}
 
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
@@ -90,8 +95,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     steps:
     - template: templates/use-python-step.yml
@@ -114,8 +118,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     steps:
     - template: templates/use-python-step.yml
@@ -139,7 +142,7 @@ stages:
   jobs:
   - job: j
     pool:
-      vmImage: "macOS-12"
+      vmImage: ${{ variables.IosTestAgentVmImage }}
 
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
@@ -183,7 +186,7 @@ stages:
   jobs:
   - job: j
     pool:
-      vmImage: "macOS-12"
+      vmImage: ${{ variables.IosTestAgentVmImage }}
 
     variables:
       OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
@@ -226,8 +229,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     steps:
     - template: templates/use-python-step.yml
@@ -266,8 +268,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     strategy:
       matrix:
@@ -314,8 +315,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     steps:
     - template: templates/use-python-step.yml
@@ -340,7 +340,7 @@ stages:
   jobs:
   - job: j
     pool:
-      vmImage: "macOS-12"
+      vmImage: ${{ variables.IosTestAgentVmImage }}
 
     steps:
     
@@ -358,8 +358,7 @@ stages:
   dependsOn: ProcessParameters
   jobs:
   - job: j
-    pool:
-      vmImage: "macOS-12"
+    pool: ${{ variables.AndroidTestAgentPool }}
 
     steps:
     - template: templates/use-python-step.yml
@@ -386,7 +385,7 @@ stages:
   jobs:
   - job: j
     pool:
-      vmImage: "macOS-12"
+      vmImage: ${{ variables.IosTestAgentVmImage }}
 
     steps:
     - script: pod install

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -4,367 +4,398 @@ parameters:
   type: string
   default: "default"
 
-jobs:
+stages:
+- stage: ProcessParameters
+  dependsOn: []
+  jobs:
+  - job: j
+    pool:
+      vmImage: "ubuntu-20.04"
 
-- job: ProcessParameters
-  pool:
-    vmImage: "ubuntu-20.04"
+    steps:
+    - checkout: none
 
-  steps:
-  - checkout: none
+    - template: templates/use-python-step.yml
 
-  - template: templates/use-python-step.yml
+    - task: PythonScript@0
+      inputs:
+        scriptSource: "inline"
+        script: |
+          import sys
+          import re
 
-  - task: PythonScript@0
-    inputs:
-      scriptSource: "inline"
-      script: |
-        import sys
-        import re
+          version_str = sys.argv[1]
+          if re.fullmatch(r"[\w\.\-\+]+", version_str) is None:
+              raise ValueError(f"Invalid version: '{version_str}'")
 
-        version_str = sys.argv[1]
-        if re.fullmatch(r"[\w\.\-\+]+", version_str) is None:
-            raise ValueError(f"Invalid version: '{version_str}'")
+          if version_str == "default":
+              pod_version_specifier = ""
+          else:
+              pod_version_specifier = f", '{version_str}'"
 
-        if version_str == "default":
-            pod_version_specifier = ""
-        else:
-            pod_version_specifier = f", '{version_str}'"
-
-        print(f"##vso[task.setvariable variable=OrtPodVersionSpecifier;isoutput=true]{pod_version_specifier}")
-      arguments: "${{ parameters.OrtPodVersion }}"
-    name: SetVariables
-    displayName: "Set variables"
+          print(f"##vso[task.setvariable variable=OrtPodVersionSpecifier;isoutput=true]{pod_version_specifier}")
+        arguments: "${{ parameters.OrtPodVersion }}"
+      name: SetVariables
+      displayName: "Set variables"
 
 # mobile/examples/basic_usage/ios
-- job: BasicUsageIos
-  pool:
-    vmImage: "macOS-12"
-
+- stage: BasicUsageIos
   dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  variables:
-    OrtPodVersionSpecifier: $[ dependencies.ProcessParameters.outputs['SetVariables.OrtPodVersionSpecifier'] ]
+    dependsOn: ProcessParameters
 
-  strategy:
-    matrix:
-      full:
-        OrtPodNamePrefix: onnxruntime
-        XcodeArgs: 'GCC_PREPROCESSOR_DEFINITIONS="$GCC_PREPROCESSOR_DEFINITIONS ORT_BASIC_USAGE_USE_ONNX_FORMAT_MODEL"'
-      mobile:
-        OrtPodNamePrefix: onnxruntime-mobile
-        XcodeArgs: ''
+    variables:
+      OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 
-  steps:
-  - template: templates/use-python-step.yml
+    strategy:
+      matrix:
+        full:
+          OrtPodNamePrefix: onnxruntime
+          XcodeArgs: 'GCC_PREPROCESSOR_DEFINITIONS="$GCC_PREPROCESSOR_DEFINITIONS ORT_BASIC_USAGE_USE_ONNX_FORMAT_MODEL"'
+        mobile:
+          OrtPodNamePrefix: onnxruntime-mobile
+          XcodeArgs: ''
 
-  - bash: |
-      set -e
-      pip install -r ../model/requirements.txt
-      ../model/gen_model.sh ./OrtBasicUsage/model
-    workingDirectory: mobile/examples/basic_usage/ios
-    displayName: "Generate model"
+    steps:
+    - template: templates/use-python-step.yml
 
-  - bash: |
-      set -e
-      PODFILE=mobile/examples/basic_usage/ios/Podfile
-      sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-      cat ${PODFILE}
-    displayName: "Update Podfile"
+    - bash: |
+        set -e
+        pip install -r ../model/requirements.txt
+        ../model/gen_model.sh ./OrtBasicUsage/model
+      workingDirectory: mobile/examples/basic_usage/ios
+      displayName: "Generate model"
 
-  - script: pod install
-    workingDirectory: 'mobile/examples/basic_usage/ios'
-    displayName: "Install CocoaPods pods"
+    - bash: |
+        set -e
+        PODFILE=mobile/examples/basic_usage/ios/Podfile
+        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
+        cat ${PODFILE}
+      displayName: "Update Podfile"
 
-  - template: templates/xcode-build-and-test-step.yml
-    parameters:
-      xcWorkspacePath: 'mobile/examples/basic_usage/ios/OrtBasicUsage.xcworkspace'
-      scheme: 'OrtBasicUsage'
-      args: $(XcodeArgs)
+    - script: pod install
+      workingDirectory: 'mobile/examples/basic_usage/ios'
+      displayName: "Install CocoaPods pods"
+
+    - template: templates/xcode-build-and-test-step.yml
+      parameters:
+        xcWorkspacePath: 'mobile/examples/basic_usage/ios/OrtBasicUsage.xcworkspace'
+        scheme: 'OrtBasicUsage'
+        args: $(XcodeArgs)
 
 # mobile/examples/whisper/local/android
-- job: WhisperLocalAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: WhisperLocalAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
 
-  - template: templates/use-jdk-step.yml
-    parameters:
-      jdkVersion: "17"
+    - template: templates/use-jdk-step.yml
+      parameters:
+        jdkVersion: "17"
 
-  - template: templates/run-with-android-emulator-steps.yml
-    parameters:
-      steps:
-      - bash: |
-          set -e
-          ./gradlew connectedDebugAndroidTest --no-daemon
-        workingDirectory: mobile/examples/whisper/local/android
-        displayName: "Build and run tests"
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/whisper/local/android
+          displayName: "Build and run tests"
 
 # mobile/examples/whisper/azure/android
-- job: WhisperAzureAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: WhisperAzureAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
 
-  - template: templates/use-jdk-step.yml
-    parameters:
-      jdkVersion: "17"
+    - template: templates/use-jdk-step.yml
+      parameters:
+        jdkVersion: "17"
 
-  - template: templates/run-with-android-emulator-steps.yml
-    parameters:
-      steps:
-      - bash: |
-          set -e
-          ./gradlew connectedDebugAndroidTest --no-daemon
-        workingDirectory: mobile/examples/whisper/azure/android
-        displayName: "Build and run tests"
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/whisper/azure/android
+          displayName: "Build and run tests"
 
 # mobile/examples/speech_recognition/ios
-- job: SpeechRecognitionIos
-  pool:
-    vmImage: "macOS-12"
-
+- stage: SpeechRecognitionIos
   dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  variables:
-    OrtPodVersionSpecifier: $[ dependencies.ProcessParameters.outputs['SetVariables.OrtPodVersionSpecifier'] ]
+    variables:
+      OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 
-  strategy:
-    matrix:
-      full:
-        OrtPodNamePrefix: onnxruntime
-      mobile:
-        OrtPodNamePrefix: onnxruntime-mobile
+    strategy:
+      matrix:
+        full:
+          OrtPodNamePrefix: onnxruntime
+        mobile:
+          OrtPodNamePrefix: onnxruntime-mobile
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
 
-  - bash: |
-      set -e
-      pip install -r ../model/requirements.txt
-      ../model/gen_model.sh ./SpeechRecognition/model
-    workingDirectory: mobile/examples/speech_recognition/ios
-    displayName: "Generate model"
+    - bash: |
+        set -e
+        pip install -r ../model/requirements.txt
+        ../model/gen_model.sh ./SpeechRecognition/model
+      workingDirectory: mobile/examples/speech_recognition/ios
+      displayName: "Generate model"
 
-  - bash: |
-      set -e
-      PODFILE=mobile/examples/speech_recognition/ios/Podfile
-      sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-      cat ${PODFILE}
-    displayName: "Update Podfile"
+    - bash: |
+        set -e
+        PODFILE=mobile/examples/speech_recognition/ios/Podfile
+        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
+        cat ${PODFILE}
+      displayName: "Update Podfile"
 
-  - script: pod install
-    workingDirectory: 'mobile/examples/speech_recognition/ios'
-    displayName: "Install CocoaPods pods"
+    - script: pod install
+      workingDirectory: 'mobile/examples/speech_recognition/ios'
+      displayName: "Install CocoaPods pods"
 
-  - template: templates/xcode-build-and-test-step.yml
-    parameters:
-      xcWorkspacePath: 'mobile/examples/speech_recognition/ios/SpeechRecognition.xcworkspace'
-      scheme: 'SpeechRecognition'
+    - template: templates/xcode-build-and-test-step.yml
+      parameters:
+        xcWorkspacePath: 'mobile/examples/speech_recognition/ios/SpeechRecognition.xcworkspace'
+        scheme: 'SpeechRecognition'
 
 # mobile/examples/object_detection/ios
-- job: ObjectDetectionIos
-  pool:
-    vmImage: "macOS-12"
-
+- stage: ObjectDetectionIos
   dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  variables:
-    OrtPodVersionSpecifier: $[ dependencies.ProcessParameters.outputs['SetVariables.OrtPodVersionSpecifier'] ]
+    variables:
+      OrtPodVersionSpecifier: $[ stageDependencies.ProcessParameters.j.outputs['SetVariables.OrtPodVersionSpecifier'] ]
 
-  strategy:
-    matrix:
-      full:
-        OrtPodNamePrefix: onnxruntime
-      mobile:
-        OrtPodNamePrefix: onnxruntime-mobile
+    strategy:
+      matrix:
+        full:
+          OrtPodNamePrefix: onnxruntime
+        mobile:
+          OrtPodNamePrefix: onnxruntime-mobile
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
 
-  - bash: |
-      set -e
-      pip install -r ./prepare_model.requirements.txt
-      ./prepare_model.sh
-    workingDirectory: mobile/examples/object_detection/ios/ORTObjectDetection
-    displayName: "Generate model"
+    - bash: |
+        set -e
+        pip install -r ./prepare_model.requirements.txt
+        ./prepare_model.sh
+      workingDirectory: mobile/examples/object_detection/ios/ORTObjectDetection
+      displayName: "Generate model"
 
-  - bash: |
-      set -e
-      PODFILE=mobile/examples/object_detection/ios/Podfile
-      sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
-      cat ${PODFILE}
-    displayName: "Update Podfile"
+    - bash: |
+        set -e
+        PODFILE=mobile/examples/object_detection/ios/Podfile
+        sed -i "" -e "s/pod 'onnxruntime-objc'/pod '$(OrtPodNamePrefix)-objc'$(OrtPodVersionSpecifier)/" ${PODFILE}
+        cat ${PODFILE}
+      displayName: "Update Podfile"
 
-  - script: pod install
-    workingDirectory: 'mobile/examples/object_detection/ios'
-    displayName: "Install CocoaPods pods"
+    - script: pod install
+      workingDirectory: 'mobile/examples/object_detection/ios'
+      displayName: "Install CocoaPods pods"
 
-  - template: templates/xcode-build-and-test-step.yml
-    parameters:
-      xcWorkspacePath: 'mobile/examples/object_detection/ios/ORTObjectDetection.xcworkspace'
-      scheme: 'ORTObjectDetection'
+    - template: templates/xcode-build-and-test-step.yml
+      parameters:
+        xcWorkspacePath: 'mobile/examples/object_detection/ios/ORTObjectDetection.xcworkspace'
+        scheme: 'ORTObjectDetection'
 
 # mobile/examples/object_detection/android
-- job: ObjectDetectionAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: ObjectDetectionAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
+      
+    - script: |
+        python3 ./ci_build/python/run_android_emulator.py \
+          --android-sdk-root ${ANDROID_SDK_ROOT} \
+          --create-avd --system-image "system-images;android-30;default;x86_64" \
+          --start --emulator-extra-args="-partition-size 4096" \
+          --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
+      displayName: "Start Android emulator"
     
-  - script: |
-      python3 ./ci_build/python/run_android_emulator.py \
-        --android-sdk-root ${ANDROID_SDK_ROOT} \
-        --create-avd --system-image "system-images;android-30;default;x86_64" \
-        --start --emulator-extra-args="-partition-size 4096" \
-        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-    displayName: "Start Android emulator"
-  
-  - task: JavaToolInstaller@0
-    displayName: Use jdk 11
-    inputs:
-      versionSpec: "11"
-      jdkArchitectureOption: "x64"
-      jdkSourceOption: "PreInstalled"
+    - task: JavaToolInstaller@0
+      displayName: Use jdk 11
+      inputs:
+        versionSpec: "11"
+        jdkArchitectureOption: "x64"
+        jdkSourceOption: "PreInstalled"
 
-  - bash: |
-      set -e
-      ./gradlew connectedDebugAndroidTest --no-daemon
-    workingDirectory: mobile/examples/object_detection/android
-    displayName: "Build and run tests"
+    - bash: |
+        set -e
+        ./gradlew connectedDebugAndroidTest --no-daemon
+      workingDirectory: mobile/examples/object_detection/android
+      displayName: "Build and run tests"
 
-  - script: |
-      python ./ci_build/python/run_android_emulator.py \
-        --android-sdk-root ${ANDROID_SDK_ROOT} \
-        --stop \
-        --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-    displayName: "Stop Android emulator"
-    condition: always()
+    - script: |
+        python ./ci_build/python/run_android_emulator.py \
+          --android-sdk-root ${ANDROID_SDK_ROOT} \
+          --stop \
+          --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
+      displayName: "Stop Android emulator"
+      condition: always()
 
 # mobile/examples/image_classification/android
-- job: ImageClassificationAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: ImageClassificationAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  strategy:
-    matrix:
-      full:
-        OrtPackageName: onnxruntime-android
-        ModelFormat: onnx
-      mobile:
-        OrtPackageName: onnxruntime-mobile
-        ModelFormat: ort
+    strategy:
+      matrix:
+        full:
+          OrtPackageName: onnxruntime-android
+          ModelFormat: onnx
+        mobile:
+          OrtPackageName: onnxruntime-mobile
+          ModelFormat: ort
 
-  steps:
-  - template: templates/use-python-step.yml
+    steps:
+    - template: templates/use-python-step.yml
 
-  - template: templates/use-jdk-step.yml
+    - template: templates/use-jdk-step.yml
 
-  - bash: |
-      set -e
-      pip install -r ./prepare_models.requirements.txt
-      ./prepare_models.py --output_dir ./app/src/main/res/raw --format $(ModelFormat)
-    workingDirectory: mobile/examples/image_classification/android
-    displayName: "Generate models"
+    - bash: |
+        set -e
+        pip install -r ./prepare_models.requirements.txt
+        ./prepare_models.py --output_dir ./app/src/main/res/raw --format $(ModelFormat)
+      workingDirectory: mobile/examples/image_classification/android
+      displayName: "Generate models"
 
-  - bash: |
-      set -e
-      GRADLE_FILE=mobile/examples/image_classification/android/app/build.gradle
-      sed -i "" \
-        -e "s/implementation 'com.microsoft.onnxruntime:onnxruntime-android:latest.release'/implementation 'com.microsoft.onnxruntime:$(OrtPackageName):latest.release'/" \
-        ${GRADLE_FILE}
-      cat ${GRADLE_FILE}
-    displayName: "Update build.gradle"
+    - bash: |
+        set -e
+        GRADLE_FILE=mobile/examples/image_classification/android/app/build.gradle
+        sed -i "" \
+          -e "s/implementation 'com.microsoft.onnxruntime:onnxruntime-android:latest.release'/implementation 'com.microsoft.onnxruntime:$(OrtPackageName):latest.release'/" \
+          ${GRADLE_FILE}
+        cat ${GRADLE_FILE}
+      displayName: "Update build.gradle"
 
-  - template: templates/run-with-android-emulator-steps.yml
-    parameters:
-      steps:
-      - bash: ./gradlew connectedDebugAndroidTest --no-daemon
-        workingDirectory: mobile/examples/image_classification/android
-        displayName: "Build and run tests"
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/image_classification/android
+          displayName: "Build and run tests"
 
 # Note: start with testing with the included aar package, 
 # can update with testing with Full/Mobile packages as the other samples later.
 
 # mobile/examples/super_resolution/android 
-- job: SuperResolutionAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: SuperResolutionAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - template: templates/use-python-step.yml
-  
-  - template: templates/use-jdk-step.yml
+    steps:
+    - template: templates/use-python-step.yml
+    
+    - template: templates/use-jdk-step.yml
 
-  - template: templates/run-with-android-emulator-steps.yml
-    parameters:
-      steps:
-      - bash: |
-          set -e
-          ./gradlew connectedDebugAndroidTest --no-daemon
-        workingDirectory: mobile/examples/super_resolution/android
-        displayName: "Build and run tests"
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/super_resolution/android
+          displayName: "Build and run tests"
 
 # Note: start with testing with the pre-release version pods.
 # can update with testing with Full/Mobile pods as the other samples later.
 
 # mobile/examples/super_resolution/ios
-- job: SuperResolutionIos
-  pool:
-    vmImage: "macOS-12"
+- stage: SuperResolutionIos
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  
-  - script: pod install
-    workingDirectory: 'mobile/examples/super_resolution/ios/ORTSuperResolution'
-    displayName: "Install CocoaPods pods"
+    steps:
+    
+    - script: pod install
+      workingDirectory: 'mobile/examples/super_resolution/ios/ORTSuperResolution'
+      displayName: "Install CocoaPods pods"
 
-  - template: templates/xcode-build-and-test-step.yml
-    parameters:
-      xcWorkspacePath: 'mobile/examples/super_resolution/ios/ORTSuperResolution/ORTSuperResolution.xcworkspace'
-      scheme: 'ORTSuperResolution'
+    - template: templates/xcode-build-and-test-step.yml
+      parameters:
+        xcWorkspacePath: 'mobile/examples/super_resolution/ios/ORTSuperResolution/ORTSuperResolution.xcworkspace'
+        scheme: 'ORTSuperResolution'
 
 # mobile/examples/question_answering/android
-- job: QuestionAnsweringAndroid
-  pool:
-    vmImage: "macOS-12"
+- stage: QuestionAnsweringAndroid
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - template: templates/use-python-step.yml
-  - bash: |
-      set -e
-      bash ./prepare_model.sh
-    workingDirectory: 'mobile/examples/question_answering/android'
-    displayName: "Generate model"
-  
-  - template: templates/use-jdk-step.yml
+    steps:
+    - template: templates/use-python-step.yml
+    - bash: |
+        set -e
+        bash ./prepare_model.sh
+      workingDirectory: 'mobile/examples/question_answering/android'
+      displayName: "Generate model"
+    
+    - template: templates/use-jdk-step.yml
 
-  - template: templates/run-with-android-emulator-steps.yml
-    parameters:
-      steps:
-      - bash: |
-          set -e
-          ./gradlew connectedDebugAndroidTest --no-daemon
-        workingDirectory: mobile/examples/question_answering/android
-        displayName: "Build and run tests"
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/question_answering/android
+          displayName: "Build and run tests"
 
 # mobile/examples/question_answering/ios
-- job: QuestionAnsweringIos
-  pool:
-    vmImage: "macOS-12"
+- stage: QuestionAnsweringIos
+  dependsOn: ProcessParameters
+  jobs:
+  - job: j
+    pool:
+      vmImage: "macOS-12"
 
-  steps:
-  - script: pod install
-    workingDirectory: 'mobile/examples/question_answering/ios/ORTQuestionAnswering'
-    displayName: "Install CocoaPods pods"
+    steps:
+    - script: pod install
+      workingDirectory: 'mobile/examples/question_answering/ios/ORTQuestionAnswering'
+      displayName: "Install CocoaPods pods"
 
-  - template: templates/xcode-build-and-test-step.yml
-    parameters:
-      xcWorkspacePath: 'mobile/examples/question_answering/ios/ORTQuestionAnswering/ORTQuestionAnswering.xcworkspace'
-      scheme: 'ORTQuestionAnswering'
+    - template: templates/xcode-build-and-test-step.yml
+      parameters:
+        xcWorkspacePath: 'mobile/examples/question_answering/ios/ORTQuestionAnswering/ORTQuestionAnswering.xcworkspace'
+        scheme: 'ORTQuestionAnswering'

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -97,8 +97,6 @@ stages:
     - template: templates/use-python-step.yml
 
     - template: templates/use-jdk-step.yml
-      parameters:
-        jdkVersion: "17"
 
     - template: templates/run-with-android-emulator-steps.yml
       parameters:
@@ -120,8 +118,6 @@ stages:
     - template: templates/use-python-step.yml
 
     - template: templates/use-jdk-step.yml
-      parameters:
-        jdkVersion: "17"
 
     - template: templates/run-with-android-emulator-steps.yml
       parameters:

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -207,14 +207,6 @@ stages:
 
     steps:
     - template: templates/use-python-step.yml
-      
-    - script: |
-        python3 ./ci_build/python/run_android_emulator.py \
-          --android-sdk-root ${ANDROID_SDK_ROOT} \
-          --create-avd --system-image "system-images;android-30;default;x86_64" \
-          --start --emulator-extra-args="-partition-size 4096" \
-          --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-      displayName: "Start Android emulator"
     
     - task: JavaToolInstaller@0
       displayName: Use jdk 11
@@ -223,19 +215,14 @@ stages:
         jdkArchitectureOption: "x64"
         jdkSourceOption: "PreInstalled"
 
-    - bash: |
-        set -e
-        ./gradlew connectedDebugAndroidTest --no-daemon
-      workingDirectory: mobile/examples/object_detection/android
-      displayName: "Build and run tests"
-
-    - script: |
-        python ./ci_build/python/run_android_emulator.py \
-          --android-sdk-root ${ANDROID_SDK_ROOT} \
-          --stop \
-          --emulator-pid-file $(Build.BinariesDirectory)/emulator.pid
-      displayName: "Stop Android emulator"
-      condition: always()
+    - template: templates/run-with-android-emulator-steps.yml
+      parameters:
+        steps:
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
+          workingDirectory: mobile/examples/object_detection/android
+          displayName: "Build and run tests"
 
 # mobile/examples/image_classification/android
 - stage: ImageClassificationAndroid
@@ -266,7 +253,9 @@ stages:
     - template: templates/run-with-android-emulator-steps.yml
       parameters:
         steps:
-        - bash: ./gradlew connectedDebugAndroidTest --no-daemon
+        - bash: |
+            set -e
+            ./gradlew connectedDebugAndroidTest --no-daemon
           workingDirectory: mobile/examples/image_classification/android
           displayName: "Build and run tests"
 

--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -155,7 +155,7 @@ stages:
 
     - template: templates/update-podfile-step.yml
       parameters:
-        podfilePath: 'mobile/examples/basic_usage/ios/Podfile'
+        podfilePath: 'mobile/examples/speech_recognition/ios/Podfile'
         ortPodVersionSpecifier: $(OrtPodVersionSpecifier)
 
     - script: pod install
@@ -190,7 +190,7 @@ stages:
 
     - template: templates/update-podfile-step.yml
       parameters:
-        podfilePath: 'mobile/examples/basic_usage/ios/Podfile'
+        podfilePath: 'mobile/examples/object_detection/ios/Podfile'
         ortPodVersionSpecifier: $(OrtPodVersionSpecifier)
 
     - script: pod install

--- a/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
+++ b/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
@@ -10,8 +10,8 @@ steps:
 
     python ./ci_build/python/run_android_emulator.py \
       --android-sdk-root "${ANDROID_SDK_ROOT}" \
-      --create-avd --system-image "system-images;android-30;default;x86_64" \
-      --start --emulator-extra-args="-partition-size 4096" \
+      --create-avd --system-image "system-images;android-31;default;x86_64" \
+      --start --emulator-extra-args="-partition-size 2047" \
       --emulator-pid-file "${ORT_EXAMPLES_BUILD_ANDROID_EMULATOR_PID_FILE}"
 
     set +x  # do not output next line or it may be parsed again with a trailing quote
@@ -19,6 +19,12 @@ steps:
   displayName: "Create and start Android emulator"
 
 - ${{ parameters.steps }}
+
+- script: |
+    set -e -x
+    python3 -m pip install psutil
+  displayName: Install psutil for emulator shutdown by run_android_emulator.py
+  condition: always()
 
 - bash: |
     set -e -x

--- a/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
+++ b/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
@@ -3,7 +3,16 @@ parameters:
   type: stepList
 
 steps:
-- bash: |
+- script: |
+    if [[ ":$PATH:" == *":${ANDROID_SDK_ROOT}/emulator:"* ]]; then
+      echo "${ANDROID_SDK_ROOT}/emulator is in PATH"
+    else
+      ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "emulator"
+      echo "##vso[task.prependpath]${ANDROID_SDK_ROOT}/emulator"
+    fi
+  displayName: Check if emulator are installed and add to PATH
+
+- script: |
     set -e -x
 
     ORT_EXAMPLES_BUILD_ANDROID_EMULATOR_PID_FILE="$(Build.BinariesDirectory)/android_emulator.pid"
@@ -26,7 +35,7 @@ steps:
   displayName: Install psutil for emulator shutdown by run_android_emulator.py
   condition: always()
 
-- bash: |
+- script: |
     set -e -x
 
     if [[ -n "${ORT_EXAMPLES_BUILD_ANDROID_EMULATOR_PID_FILE-}" ]]; then

--- a/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
+++ b/ci_build/azure_pipelines/templates/run-with-android-emulator-steps.yml
@@ -10,7 +10,17 @@ steps:
       ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "emulator"
       echo "##vso[task.prependpath]${ANDROID_SDK_ROOT}/emulator"
     fi
-  displayName: Check if emulator are installed and add to PATH
+  displayName: Check if emulator is installed and add to PATH
+
+- script: |
+    if [[ ":$PATH:" == *":${ANDROID_SDK_ROOT}/platform-tools:"* ]]; then
+        echo "${ANDROID_SDK_ROOT}/platform-tools is in PATH"
+    else
+        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "platform-tools"
+        echo "##vso[task.prependpath]${ANDROID_SDK_ROOT}/platform-tools"
+    fi
+    ls -R ${ANDROID_SDK_ROOT}/platform-tools
+  displayName: Check if platform tools are installed and add to PATH
 
 - script: |
     set -e -x

--- a/ci_build/azure_pipelines/templates/update-podfile-step.yml
+++ b/ci_build/azure_pipelines/templates/update-podfile-step.yml
@@ -1,0 +1,24 @@
+parameters:
+- name: podfilePath
+  type: string
+- name: ortPodVersionSpecifier
+  type: string
+  default: ""
+- name: ortPodName
+  type: string
+  default: "onnxruntime-objc"
+
+steps:
+- bash: |
+    set -e
+
+    if [[ -z "${{ parameters.OrtPodVersionSpecifier }}" ]]; then
+      echo "Using original Podfile"
+      exit 0
+    fi
+
+    PODFILE="${{ parameters.PodfilePath }}"
+    ORT_POD_NAME="${{ parameters.OrtPodName }}"
+    sed -i "" -e "s/pod '${ORT_POD_NAME}'/pod '${ORT_POD_NAME}'$(OrtPodVersionSpecifier)/" "${PODFILE}"
+    cat "${PODFILE}"
+  displayName: "Update Podfile at ${{ parameters.PodfilePath }}"

--- a/ci_build/azure_pipelines/templates/use-jdk-step.yml
+++ b/ci_build/azure_pipelines/templates/use-jdk-step.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: jdkVersion
   type: string
-  default: "11"
+  default: "17"
 
 steps:
 - task: JavaToolInstaller@0

--- a/ci_build/azure_pipelines/templates/use-python-step.yml
+++ b/ci_build/azure_pipelines/templates/use-python-step.yml
@@ -1,7 +1,12 @@
+parameters:
+- name: pythonVersion
+  type: string
+  default: "3.9"
+
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.9'
+    versionSpec: "${{ parameters.pythonVersion }}"
     addToPath: true
     architecture: 'x64'
-  displayName: "Use Python 3.9"
+  displayName: "Use Python ${{ parameters.pythonVersion }}"

--- a/ci_build/python/run_android_emulator.py
+++ b/ci_build/python/run_android_emulator.py
@@ -7,9 +7,8 @@ import contextlib
 import shlex
 import sys
 
-from util.logger import get_logger
 import util.android as android
-
+from util.logger import get_logger
 
 log = get_logger("run_android_emulator")
 
@@ -17,38 +16,35 @@ log = get_logger("run_android_emulator")
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Manages the running of an Android emulator. "
-        "Supported modes are to start and stop (default), only start, or only "
-        "stop the emulator.")
+        "Supported modes are to create an AVD, and start or stop the emulator. "
+        "The default is to start the emulator and wait for a keypress to stop it (start and stop)."
+    )
 
-    parser.add_argument(
-        "--create-avd", action="store_true",
-        help="Whether to create the Android virtual device.")
+    parser.add_argument("--create-avd", action="store_true", help="Whether to create the Android virtual device.")
 
-    parser.add_argument(
-        "--start", action="store_true", help="Start the emulator.")
-    parser.add_argument(
-        "--stop", action="store_true", help="Stop the emulator.")
+    parser.add_argument("--start", action="store_true", help="Start the emulator.")
+    parser.add_argument("--stop", action="store_true", help="Stop the emulator.")
 
+    parser.add_argument("--android-sdk-root", required=True, help="Path to the Android SDK root.")
     parser.add_argument(
-        "--android-sdk-root", required=True, help="Path to the Android SDK root.")
+        "--system-image",
+        default="system-images;android-31;default;x86_64",
+        help="The Android system image package name.",
+    )
+    parser.add_argument("--avd-name", default="ort_android", help="The Android virtual device name.")
     parser.add_argument(
-        "--system-image", default="system-images;android-29;google_apis;x86_64",
-        help="The Android system image package name.")
-    parser.add_argument(
-        "--avd-name", default="ort_android",
-        help="The Android virtual device name.")
-    parser.add_argument(
-        "--emulator-extra-args", default="",
-        help="A string of extra arguments to pass to the Android emulator.")
+        "--emulator-extra-args", default="", help="A string of extra arguments to pass to the Android emulator."
+    )
     parser.add_argument(
         "--emulator-pid-file",
         help="Output/input file containing the PID of the emulator process. "
-        "This is only required if exactly one of --start or --stop is given.")
+        "This is only required if exactly one of --start or --stop is given.",
+    )
 
     args = parser.parse_args()
 
-    if not args.start and not args.stop:
-        # unspecified means start and stop
+    if not args.start and not args.stop and not args.create_avd:
+        # unspecified means start and stop if not creating the AVD
         args.start = args.stop = True
 
     if args.start != args.stop and args.emulator_pid_file is None:
@@ -84,10 +80,10 @@ def main():
         emulator_proc = android.start_emulator(**start_emulator_args)
 
         with open(args.emulator_pid_file, mode="w") as emulator_pid_file:
-            print("{}".format(emulator_proc.pid), file=emulator_pid_file)
+            print(f"{emulator_proc.pid}", file=emulator_pid_file)
 
     elif args.stop:
-        with open(args.emulator_pid_file, mode="r") as emulator_pid_file:
+        with open(args.emulator_pid_file) as emulator_pid_file:
             emulator_pid = int(emulator_pid_file.readline().strip())
 
         android.stop_emulator(emulator_pid)

--- a/ci_build/python/util/android/android.py
+++ b/ci_build/python/util/android/android.py
@@ -3,23 +3,18 @@
 
 import collections
 import contextlib
-import logging
-import os
-import shutil
+import datetime
 import signal
 import subprocess
-import sys
 import time
 import typing
+from pathlib import Path
 
+from ..logger import get_logger
+from ..platform_helpers import is_linux, is_windows
 from ..run import run
 
-
-_log = logging.getLogger("util.android")
-
-
-def is_windows():
-    return sys.platform.startswith("win")
+_log = get_logger("util.android")
 
 
 SdkToolPaths = collections.namedtuple("SdkToolPaths", ["emulator", "adb", "sdkmanager", "avdmanager"])
@@ -28,30 +23,21 @@ SdkToolPaths = collections.namedtuple("SdkToolPaths", ["emulator", "adb", "sdkma
 def get_sdk_tool_paths(sdk_root: str):
     def filename(name, windows_extension):
         if is_windows():
-            return "{}.{}".format(name, windows_extension)
+            return f"{name}.{windows_extension}"
         else:
             return name
 
-    def resolve_path(dirnames, basename):
-        dirnames.insert(0, "")
-        for dirname in dirnames:
-            path = shutil.which(os.path.join(dirname, basename))
-            if path is not None:
-                path = os.path.realpath(path)
-                _log.debug("Found {} at {}".format(basename, path))
-                return path
-        raise FileNotFoundError("Failed to resolve path for {}".format(basename))
+    sdk_root = Path(sdk_root).resolve(strict=True)
 
     return SdkToolPaths(
-        emulator=resolve_path([os.path.join(sdk_root, "emulator")], filename("emulator", "exe")),
-        adb=resolve_path([os.path.join(sdk_root, "platform-tools")], filename("adb", "exe")),
-        sdkmanager=resolve_path(
-            [os.path.join(sdk_root, "cmdline-tools", "latest", "bin")],
-            filename("sdkmanager", "bat"),
+        # do not use sdk_root/tools/emulator as that is superseded by sdk_root/emulator/emulator
+        emulator=str((sdk_root / "emulator" / filename("emulator", "exe")).resolve(strict=True)),
+        adb=str((sdk_root / "platform-tools" / filename("adb", "exe")).resolve(strict=True)),
+        sdkmanager=str(
+            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("sdkmanager", "bat")).resolve(strict=True)
         ),
-        avdmanager=resolve_path(
-            [os.path.join(sdk_root, "cmdline-tools", "latest", "bin")],
-            filename("avdmanager", "bat"),
+        avdmanager=str(
+            (sdk_root / "cmdline-tools" / "latest" / "bin" / filename("avdmanager", "bat")).resolve(strict=True)
         ),
     )
 
@@ -76,7 +62,7 @@ _process_creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if is_windows() els
 
 
 def _start_process(*args) -> subprocess.Popen:
-    _log.debug("Starting process - args: {}".format([*args]))
+    _log.debug(f"Starting process - args: {[*args]}")
     return subprocess.Popen([*args], creationflags=_process_creationflags)
 
 
@@ -84,7 +70,11 @@ _stop_signal = signal.CTRL_BREAK_EVENT if is_windows() else signal.SIGTERM
 
 
 def _stop_process(proc: subprocess.Popen):
-    _log.debug("Stopping process - args: {}".format(proc.args))
+    if proc.returncode is not None:
+        # process has exited
+        return
+
+    _log.debug(f"Stopping process - args: {proc.args}")
     proc.send_signal(_stop_signal)
 
     try:
@@ -95,9 +85,23 @@ def _stop_process(proc: subprocess.Popen):
 
 
 def _stop_process_with_pid(pid: int):
-    # not attempting anything fancier than just sending _stop_signal for now
-    _log.debug("Stopping process - pid: {}".format(pid))
-    os.kill(pid, _stop_signal)
+    # minimize scope of external module usage
+    import psutil
+
+    if psutil.pid_exists(pid):
+        process = psutil.Process(pid)
+        _log.debug(f"Stopping process - pid={pid}")
+        process.terminate()
+        try:
+            process.wait(60)
+        except psutil.TimeoutExpired:
+            print("Process did not terminate within 60 seconds. Killing.")
+            process.kill()
+            time.sleep(10)
+            if psutil.pid_exists(pid):
+                print(f"Process still exists. State:{process.status()}")
+    else:
+        _log.debug(f"No process exists with pid={pid}")
 
 
 def start_emulator(
@@ -112,45 +116,95 @@ def start_emulator(
             "4096",
             "-timezone",
             "America/Los_Angeles",
-            "-no-snapshot",
+            "-no-snapstorage",
             "-no-audio",
             "-no-boot-anim",
-            "-no-window",
+            "-gpu",
+            "guest",
+            "-delay-adb",
         ]
+
+        # For Linux CIs we must use "-no-window" otherwise you'll get
+        #   Fatal: This application failed to start because no Qt platform plugin could be initialized
+        #
+        # For macOS CIs use a window so that we can potentially capture the desktop and the emulator screen
+        # and publish screenshot.jpg and emulator.png as artifacts to debug issues.
+        #   screencapture screenshot.jpg
+        #   $(ANDROID_SDK_HOME)/platform-tools/adb exec-out screencap -p > emulator.png
+        #
+        # On Windows it doesn't matter (AFAIK) so allow a window which is nicer for local debugging.
+        if is_linux():
+            emulator_args.append("-no-window")
+
         if extra_args is not None:
             emulator_args += extra_args
 
         emulator_process = emulator_stack.enter_context(_start_process(*emulator_args))
         emulator_stack.callback(_stop_process, emulator_process)
 
+        # we're specifying -delay-adb so use a trivial command to check when adb is available.
         waiter_process = waiter_stack.enter_context(
             _start_process(
                 sdk_tool_paths.adb,
                 "wait-for-device",
                 "shell",
-                "while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82",
+                "ls /data/local/tmp",
             )
         )
+
         waiter_stack.callback(_stop_process, waiter_process)
 
-        # poll subprocesses
-        sleep_interval_seconds = 1
+        # poll subprocesses.
+        # allow 20 minutes for startup as some CIs are slow. TODO: Make timeout configurable if needed.
+        sleep_interval_seconds = 10
+        end_time = datetime.datetime.now() + datetime.timedelta(minutes=20)
+
         while True:
             waiter_ret, emulator_ret = waiter_process.poll(), emulator_process.poll()
 
             if emulator_ret is not None:
                 # emulator exited early
-                raise RuntimeError("Emulator exited early with return code: {}".format(emulator_ret))
+                raise RuntimeError(f"Emulator exited early with return code: {emulator_ret}")
 
             if waiter_ret is not None:
                 if waiter_ret == 0:
+                    _log.debug("adb wait-for-device process has completed.")
                     break
-                raise RuntimeError("Waiter process exited with return code: {}".format(waiter_ret))
+                raise RuntimeError(f"Waiter process exited with return code: {waiter_ret}")
+
+            if datetime.datetime.now() > end_time:
+                raise RuntimeError("Emulator startup timeout")
 
             time.sleep(sleep_interval_seconds)
 
-        # emulator is ready now
+        # emulator is started
         emulator_stack.pop_all()
+
+        # loop to check for sys.boot_completed being set.
+        # in theory `-delay-adb` should be enough but this extra check seems to be required to be sure.
+        while True:
+            # looping on device with `while` seems to be flaky so loop here and call getprop once
+            args = [
+                sdk_tool_paths.adb,
+                "shell",
+                # "while [[ -z $(getprop sys.boot_completed) | tr -d '\r' ]]; do sleep 5; done; input keyevent 82",
+                "getprop sys.boot_completed",
+            ]
+
+            _log.debug(f"Starting process - args: {args}")
+
+            getprop_output = subprocess.check_output(args, timeout=10)
+            getprop_value = bytes.decode(getprop_output).strip()
+
+            if getprop_value == "1":
+                break
+
+            elif datetime.datetime.now() > end_time:
+                raise RuntimeError("Emulator startup timeout. sys.boot_completed was not set.")
+
+            _log.debug(f"sys.boot_completed='{getprop_value}'. Sleeping for {sleep_interval_seconds} before retrying.")
+            time.sleep(sleep_interval_seconds)
+
         return emulator_process
 
 

--- a/ci_build/python/util/logger.py
+++ b/ci_build/python/util/logger.py
@@ -4,9 +4,8 @@
 import logging
 
 
-def get_logger(name):
-    logging.basicConfig(
-        format="%(asctime)s %(name)s [%(levelname)s] - %(message)s",
-        level=logging.DEBUG)
-
-    return logging.getLogger(name)
+def get_logger(name, level=logging.DEBUG):
+    logging.basicConfig(format="%(asctime)s %(name)s [%(levelname)s] - %(message)s")
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    return logger

--- a/ci_build/python/util/platform_helpers.py
+++ b/ci_build/python/util/platform_helpers.py
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import sys
+
+
+def is_windows():
+    return sys.platform.startswith("win")
+
+
+def is_macOS():  # noqa: N802
+    return sys.platform.startswith("darwin")
+
+
+def is_linux():
+    return sys.platform.startswith("linux")

--- a/ci_build/python/util/run.py
+++ b/ci_build/python/util/run.py
@@ -6,13 +6,20 @@ import os
 import shlex
 import subprocess
 
-
 _log = logging.getLogger("util.run")
 
 
-def run(*args, cwd=None,
-        input=None, capture_stdout=False, capture_stderr=False,
-        shell=False, env=None, check=True, quiet=False):
+def run(
+    *args,
+    cwd=None,
+    input=None,
+    capture_stdout=False,
+    capture_stderr=False,
+    shell=False,
+    env=None,
+    check=True,
+    quiet=False,
+):
     """Runs a subprocess.
 
     Args:
@@ -32,19 +39,24 @@ def run(*args, cwd=None,
     """
     cmd = [*args]
 
-    _log.info("Running subprocess in '{0}'\n  {1}".format(
-        cwd or os.getcwd(), " ".join([shlex.quote(arg) for arg in cmd])))
+    _log.info(
+        "Running subprocess in '{}'\n  {}".format(cwd or os.getcwd(), " ".join([shlex.quote(arg) for arg in cmd]))
+    )
 
     def output(is_stream_captured):
-        return subprocess.PIPE if is_stream_captured else \
-            (subprocess.DEVNULL if quiet else None)
+        return subprocess.PIPE if is_stream_captured else (subprocess.DEVNULL if quiet else None)
 
     completed_process = subprocess.run(
-        cmd, cwd=cwd, check=check, input=input,
-        stdout=output(capture_stdout), stderr=output(capture_stderr),
-        env=env, shell=shell)
+        cmd,
+        cwd=cwd,
+        check=check,
+        input=input,
+        stdout=output(capture_stdout),
+        stderr=output(capture_stderr),
+        env=env,
+        shell=shell,
+    )
 
-    _log.debug("Subprocess completed. Return code: {}".format(
-        completed_process.returncode))
+    _log.debug(f"Subprocess completed. Return code: {completed_process.returncode}")
 
     return completed_process

--- a/mobile/examples/basic_usage/ios/Podfile
+++ b/mobile/examples/basic_usage/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'OrtBasicUsage' do
   use_frameworks!

--- a/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.sh
+++ b/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.sh
@@ -2,27 +2,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # ============================================================
-set -e
+set -e -x
 
-MODELS_URL="https://tfhub.dev/tensorflow/lite-model/ssd_mobilenet_v1/1/metadata/1?lite-format=tflite"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 DOWNLOAD_DIR="${SCRIPT_DIR}/ModelsAndData"
 
-mkdir -p ${DOWNLOAD_DIR}
+mkdir -p "${DOWNLOAD_DIR}/tflite_model"
 
-#Download source tflite model file
-curl -L ${MODELS_URL} >${DOWNLOAD_DIR}/ssd_mobilenet_v1_1_metadata_1.tflite
+# Download source tflite model file
+curl -L -o "${DOWNLOAD_DIR}/tflite_model/model.tar.gz" \
+  https://www.kaggle.com/api/v1/models/tensorflow/ssd-mobilenet-v1/tfLite/metadata/1/download
 
-#Unzip and get model metadata
-unzip ${DOWNLOAD_DIR}/ssd_mobilenet_v1_1_metadata_1.tflite -d ${DOWNLOAD_DIR}
+# Extract model
+tar -xzf "${DOWNLOAD_DIR}/tflite_model/model.tar.gz" -C "${DOWNLOAD_DIR}/tflite_model"
 
-#Convert tflite model to onnx model
-python3 -m tf2onnx.convert --tflite ${DOWNLOAD_DIR}/ssd_mobilenet_v1_1_metadata_1.tflite --opset 13 --output ${DOWNLOAD_DIR}/ssd_mobilenet_v1.onnx
+# Convert tflite model to onnx model
+python -m tf2onnx.convert --tflite "${DOWNLOAD_DIR}/tflite_model/1.tflite" --opset 13 --output "${DOWNLOAD_DIR}/ssd_mobilenet_v1.onnx"
 
-#Convert onnx model to ort format
-#This step generates a .ort format ssd mobilenet model in /ModelsAndData.
-#The .ort format model is the one gets executed in this sample application
-python3 -m onnxruntime.tools.convert_onnx_models_to_ort ${DOWNLOAD_DIR}
+# Convert onnx model to ort format
+# This step generates a .ort format ssd mobilenet model in /ModelsAndData.
+# The .ort format model is the one gets executed in this sample application
+python -m onnxruntime.tools.convert_onnx_models_to_ort "${DOWNLOAD_DIR}/ssd_mobilenet_v1.onnx"
 
-#Remove the tflite model
-rm ${DOWNLOAD_DIR}/ssd_mobilenet_v1_1_metadata_1.tflite
+# Remove the tflite model
+rm -r "${DOWNLOAD_DIR}/tflite_model"

--- a/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.sh
+++ b/mobile/examples/object_detection/ios/ORTObjectDetection/prepare_model.sh
@@ -16,6 +16,8 @@ curl -L -o "${DOWNLOAD_DIR}/tflite_model/model.tar.gz" \
 
 # Extract model
 tar -xzf "${DOWNLOAD_DIR}/tflite_model/model.tar.gz" -C "${DOWNLOAD_DIR}/tflite_model"
+# Extract the labelmap.txt file within the tflite file
+unzip "${DOWNLOAD_DIR}/tflite_model/1.tflite" labelmap.txt -d "${DOWNLOAD_DIR}"
 
 # Convert tflite model to onnx model
 python -m tf2onnx.convert --tflite "${DOWNLOAD_DIR}/tflite_model/1.tflite" --opset 13 --output "${DOWNLOAD_DIR}/ssd_mobilenet_v1.onnx"

--- a/mobile/examples/object_detection/ios/Podfile
+++ b/mobile/examples/object_detection/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'ORTObjectDetection' do
   use_frameworks!

--- a/mobile/examples/question_answering/ios/ORTQuestionAnswering/Podfile
+++ b/mobile/examples/question_answering/ios/ORTQuestionAnswering/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'ORTQuestionAnswering' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/mobile/examples/speech_recognition/ios/Podfile
+++ b/mobile/examples/speech_recognition/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'SpeechRecognition' do
   use_frameworks!

--- a/mobile/examples/super_resolution/ios/ORTSuperResolution/Podfile
+++ b/mobile/examples/super_resolution/ios/ORTSuperResolution/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'ORTSuperResolution' do
   # Comment the next line if you don't want to use dynamic frameworks


### PR DESCRIPTION
Fix the mobile examples CI pipeline.

In particular:
- Move Android examples to run on Linux build agents
- Copy over Android emulator helper scripts from ORT at commit 5e66fcc703
- Fix model download script for iOS object detection example
- Update Podfiles to use iOS 13 as that is the new minimum version required by ORT
- Refactor CI pipeline