### PR TITLE
Update mobile/examples/speech_recognition/model dependencies.

### DIFF
--- a/mobile/examples/speech_recognition/model/requirements.txt
+++ b/mobile/examples/speech_recognition/model/requirements.txt
@@ -1,6 +1,5 @@
-onnx==1.13.0
-onnxruntime==1.13.1
-protobuf==3.20.2
-torch==2.2.0
-torchaudio==2.2.0
+onnx==1.16.1
+onnxruntime==1.19.2
+torch==2.4.1
+torchaudio==2.4.1
 transformers==4.38.0

--- a/mobile/examples/speech_recognition/model/requirements.txt
+++ b/mobile/examples/speech_recognition/model/requirements.txt
@@ -2,5 +2,5 @@ onnx==1.13.0
 onnxruntime==1.13.1
 protobuf==3.20.2
 torch==2.2.0
-torchaudio==0.13.1
+torchaudio==2.2.0
 transformers==4.38.0

--- a/mobile/examples/speech_recognition/model/requirements.txt
+++ b/mobile/examples/speech_recognition/model/requirements.txt
@@ -1,5 +1,5 @@
 onnx==1.16.1
 onnxruntime==1.19.2
-torch==2.4.1
-torchaudio==2.4.1
+torch==2.2.2
+torchaudio==2.2.2
 transformers==4.38.0

--- a/mobile/examples/speech_recognition/model/requirements.txt
+++ b/mobile/examples/speech_recognition/model/requirements.txt
@@ -1,6 +1,6 @@
 onnx==1.13.0
 onnxruntime==1.13.1
 protobuf==3.20.2
-torch==1.13.1
+torch==2.2.0
 torchaudio==0.13.1
 transformers==4.38.0

--- a/mobile/examples/speech_recognition/model/wav2vec2_gen.py
+++ b/mobile/examples/speech_recognition/model/wav2vec2_gen.py
@@ -19,4 +19,4 @@ torch.onnx.export(model, input, "wav2vec2-base-960h.onnx",
                   input_names=["input"],
                   output_names=["output"],
                   dynamic_axes={"input": [1], "output": [1]},
-                  opset_version=13)
+                  opset_version=14)


### PR DESCRIPTION
See https://github.com/microsoft/onnxruntime-inference-examples/pull/478.

Bumping the torch dependency requires some other updates. This PR updates more of them.