### PR TITLE
Update macOS image version, Xcode version, and simulator target for mobile example CI pipeline

### DIFF
--- a/ci_build/azure_pipelines/mobile-examples-pipeline.yml
+++ b/ci_build/azure_pipelines/mobile-examples-pipeline.yml
@@ -8,7 +8,7 @@ variables:
   - name: AndroidTestAgentPool
     value: "onnxruntime-Ubuntu2204-AMD-CPU"
   - name: IosTestAgentVmImage
-    value: "macOS-12"
+    value: "macOS-14"
 
 stages:
 - stage: ProcessParameters

--- a/ci_build/azure_pipelines/templates/xcode-build-and-test-step.yml
+++ b/ci_build/azure_pipelines/templates/xcode-build-and-test-step.yml
@@ -16,11 +16,11 @@ steps:
     xcWorkspacePath: '${{ parameters.xcWorkspacePath }}'
     scheme: '${{ parameters.scheme }}'
     xcodeVersion: 'specifyPath'
-    xcodeDeveloperDir: '/Applications/Xcode_14.2.app/Contents/Developer'
+    xcodeDeveloperDir: '/Applications/Xcode_15.4.app/Contents/Developer'
     packageApp: false
     destinationPlatformOption: 'iOS'
     destinationTypeOption: 'simulators'
-    destinationSimulators: 'iPhone 8'
+    destinationSimulators: 'iPhone 15'
     ${{ if ne(parameters.args, '') }}:
       args: ${{ parameters.args }}
   displayName: "Xcode build and test"


### PR DESCRIPTION
Updating because the macOS-12 image is deprecated.