### PR TITLE
Fix sd-turbo inference bug

### DIFF
--- a/js/sd-turbo/package.json
+++ b/js/sd-turbo/package.json
@@ -22,8 +22,8 @@
     "copy-webpack-plugin": "^12.0.2",
     "esbuild": "^0.20.1",
     "eslint": "^8.57.0",
-    "onnxruntime-common": "^1.17.1",
-    "onnxruntime-web": "^1.17.1",
+    "onnxruntime-common": "^1.20.0",
+    "onnxruntime-web": "^1.20.0",
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4"
   },


### PR DESCRIPTION
Updating the onnx-runtime dependencies seems sufficient to fix it.

Previously, I would get this sort of image:
![téléchargement](https://github.com/user-attachments/assets/f0df7b44-73e4-49bb-849c-84129d6c65de)

Feel free to tell me if I can do anything more :)
