### PR TITLE
Fix js/chat example

### DIFF
--- a/js/chat/package.json
+++ b/js/chat/package.json
@@ -12,7 +12,7 @@
     "@xenova/transformers": "^2.17.1",
     "copy-webpack-plugin": "^12.0.2",
     "marked": "^12.0.2",
-    "onnxruntime-web": "1.19.0-dev.20240509-69cfcba38a",
+    "onnxruntime-web": "^1.20.1",
     "webpack": "^5.91.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The chat example is broken currently, as noted in #431. TLDR: Update Onnxruntime-web in chat sample to be v1.20.1

There are two symptoms that are displayed in the console. One is a failure to initialize the session, leading to `TypeError: Cannot read properties of undefined (reading 'run')`. That error is somewhat ambiguous. However, running under a debugger we see a more descriptive error:
```
Error: no available backend found. ERR: [webgpu] TypeError: r.requestAdapterInfo is not a function
    at On (ort.webgpu.min.js:6:1623)
    at async e.create (ort.webgpu.min.js:6:18113)
    at async LLM.load (llm.js:113:1)
    at async Init (main.js:256:1)
```

Per https://issues.chromium.org/issues/346321149, `requestAdapterInfo` was deprecated. https://github.com/gyagp/onnxruntime/commit/2a70ffd5a9ee9b04cf4ece74eebd440431db2d8d is the associated PR into `onnxruntime` making the update.

This change only updates the chat sample. Other samples (ort-whisper, quick-start_onnxruntime-web-bundler, sd-turbo, and segment-anything) all use even older onnxruntime-web packages. Consider updating those as appropriate.