### PR TITLE
iOS model tester app

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,10 @@
 # Defaults for all languages.
 BasedOnStyle:  Google
 
-ColumnLimit: 120
+# Setting ColumnLimit to 0 so developer choices about where to break lines are maintained.
+# Developers are responsible for adhering to the 120 character maximum.
+ColumnLimit:     0
+SortIncludes: false
+DerivePointerAlignment: false
 
 ...

--- a/mobile/examples/model_tester/common/include/model_runner.h
+++ b/mobile/examples/model_tester/common/include/model_runner.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace model_runner {
+
+struct RunConfig {
+  std::string model_path{};
+
+  size_t num_warmup_iterations{};
+  size_t num_iterations{};
+
+  std::optional<int> log_level{};
+};
+
+using Clock = std::chrono::steady_clock;
+using Duration = Clock::duration;
+
+struct RunResult {
+  Duration load_duration;
+  std::vector<Duration> run_durations;
+};
+
+RunResult Run(const RunConfig& run_config);
+
+std::string GetRunSummary(const RunConfig& run_config, const RunResult& run_result);
+
+}  // namespace model_runner

--- a/mobile/examples/model_tester/common/model_runner.cpp
+++ b/mobile/examples/model_tester/common/model_runner.cpp
@@ -211,19 +211,16 @@ RunResult Run(const RunConfig& run_config) {
   return run_result;
 }
 
-std::string GetRunSummary(const RunConfig& run_config, const RunResult& run_result) {
+std::string GetRunSummary(const RunConfig& /*run_config*/, const RunResult& run_result) {
   auto to_display_duration = []<typename Rep, typename Period>(std::chrono::duration<Rep, Period> d) {
     using DisplayPeriod = std::chrono::microseconds::period;
     using DisplayDuration = std::chrono::duration<Rep, DisplayPeriod>;
     return std::chrono::duration_cast<DisplayDuration>(d);
   };
 
-  const auto model_path = std::filesystem::path{run_config.model_path};
-
   const auto stats = ComputeRunResultStats(run_result);
 
   const auto summary = std::format(
-      "Model: {}\n"
       "Load time: {}\n"
       "N (number of runs): {}\n"
       "Latency\n"
@@ -233,7 +230,6 @@ std::string GetRunSummary(const RunConfig& run_config, const RunResult& run_resu
       "  p99: {}\n"
       "  min: {}\n"
       "  max: {}\n",
-      model_path.filename().string(),
       to_display_duration(run_result.load_duration),
       stats.n,
       to_display_duration(stats.average),

--- a/mobile/examples/model_tester/common/model_runner.cpp
+++ b/mobile/examples/model_tester/common/model_runner.cpp
@@ -1,0 +1,249 @@
+#include "model_runner.h"
+
+#include <cstddef>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <format>
+#include <iterator>
+#include <numeric>
+#include <span>
+
+#include "onnxruntime_cxx_api.h"
+
+namespace model_runner {
+
+namespace {
+
+size_t GetDataTypeSizeInBytes(ONNXTensorElementDataType data_type) {
+  switch (data_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return 1;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+      return 8;
+    default:
+      throw std::invalid_argument(std::format("unsupported tensor data type: {}", static_cast<int>(data_type)));
+  }
+}
+
+void FillTensorWithZeroes(Ort::Value& value) {
+  const auto tensor_info = value.GetTensorTypeAndShapeInfo();
+  const auto data_type = tensor_info.GetElementType();
+  const auto num_elements = tensor_info.GetElementCount();
+  const auto data_type_size_in_bytes = GetDataTypeSizeInBytes(data_type);
+  const auto data_size_in_bytes = num_elements * data_type_size_in_bytes;
+
+  std::byte* data = static_cast<std::byte*>(value.GetTensorMutableRawData());
+  std::fill(data, data + data_size_in_bytes, std::byte{0});
+}
+
+std::vector<Ort::Value> GetModelInputValues(const Ort::Session& session) {
+  const auto num_inputs = session.GetInputCount();
+
+  std::vector<Ort::Value> input_values{};
+  input_values.reserve(num_inputs);
+
+  Ort::AllocatorWithDefaultOptions allocator{};
+
+  for (size_t i = 0; i < num_inputs; ++i) {
+    auto type_info = session.GetInputTypeInfo(i);
+    auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+
+    auto tensor_shape = tensor_info.GetShape();
+    // make this a static shape
+    for (auto& dim : tensor_shape) {
+      if (dim == -1) {
+        dim = 1;
+      }
+    }
+
+    const auto tensor_data_type = tensor_info.GetElementType();
+
+    auto value = Ort::Value::CreateTensor(allocator, tensor_shape.data(), tensor_shape.size(), tensor_data_type);
+
+    FillTensorWithZeroes(value);
+
+    input_values.emplace_back(std::move(value));
+  }
+
+  return input_values;
+}
+
+std::vector<std::string> GetModelInputOrOutputNames(const Ort::Session& session, bool is_input) {
+  const auto num_inputs_or_outputs = is_input ? session.GetInputCount() : session.GetOutputCount();
+
+  std::vector<std::string> names{};
+  names.reserve(num_inputs_or_outputs);
+
+  auto allocator = Ort::AllocatorWithDefaultOptions{};
+  for (size_t i = 0; i < num_inputs_or_outputs; ++i) {
+    auto name = is_input ? session.GetInputNameAllocated(i, allocator)
+                         : session.GetOutputNameAllocated(i, allocator);
+    names.emplace_back(name.get());
+  }
+
+  return names;
+}
+
+std::vector<std::string> GetModelInputNames(const Ort::Session& session) {
+  return GetModelInputOrOutputNames(session, /* is_input */ true);
+}
+
+std::vector<std::string> GetModelOutputNames(const Ort::Session& session) {
+  return GetModelInputOrOutputNames(session, /* is_input */ false);
+}
+
+std::vector<const char*> GetCstrs(std::span<const std::string> strs) {
+  std::vector<const char*> cstrs{};
+  cstrs.reserve(strs.size());
+  std::transform(strs.begin(), strs.end(), std::back_inserter(cstrs),
+                 [](const std::string& str) { return str.c_str(); });
+  return cstrs;
+}
+
+class Timer {
+ public:
+  Timer() { Reset(); }
+
+  void Reset() { start_ = Clock::now(); }
+
+  Duration Elapsed() const { return Clock::now() - start_; }
+
+ private:
+  Clock::time_point start_;
+};
+
+struct RunResultStats {
+  using DurationFp = std::chrono::duration<float, Duration::period>;
+
+  size_t n;
+  DurationFp average;
+  Duration min, max;
+  Duration p50, p90, p99;
+};
+
+RunResultStats ComputeRunResultStats(const RunResult& run_result) {
+  using DurationFp = RunResultStats::DurationFp;
+
+  const auto& run_durations = run_result.run_durations;
+
+  RunResultStats stats{};
+  const auto n = run_durations.size();
+  stats.n = n;
+  if (n > 0) {
+    const auto total_run_duration = std::accumulate(run_durations.begin(), run_durations.end(),
+                                                    DurationFp{0.0f});
+    stats.average = DurationFp{total_run_duration.count() / n};
+
+    auto sorted_run_durations = run_durations;
+    std::sort(sorted_run_durations.begin(), sorted_run_durations.end());
+    stats.min = sorted_run_durations.front();
+    stats.max = sorted_run_durations.back();
+    stats.p50 = sorted_run_durations[static_cast<size_t>(0.5f * n)];
+    stats.p90 = sorted_run_durations[static_cast<size_t>(0.9f * n)];
+    stats.p99 = sorted_run_durations[static_cast<size_t>(0.99f * n)];
+  }
+
+  return stats;
+}
+
+}  // namespace
+
+RunResult Run(const RunConfig& run_config) {
+  RunResult run_result{};
+
+  auto env = Ort::Env{};
+
+  if (run_config.log_level.has_value()) {
+    env.UpdateEnvWithCustomLogLevel(static_cast<OrtLoggingLevel>(*run_config.log_level));
+  }
+
+  auto session_options = Ort::SessionOptions{};
+
+  Timer timer{};
+  auto session = Ort::Session{env, run_config.model_path.c_str(), session_options};
+  run_result.load_duration = timer.Elapsed();
+
+  auto input_names = GetModelInputNames(session);
+  auto input_name_cstrs = GetCstrs(input_names);
+
+  auto input_values = GetModelInputValues(session);
+
+  auto output_names = GetModelOutputNames(session);
+  auto output_name_cstrs = GetCstrs(output_names);
+
+  auto run_options = Ort::RunOptions{};
+
+  // warmup
+  for (size_t i = 0; i < run_config.num_warmup_iterations; ++i) {
+    auto outputs = session.Run(run_options,
+                               input_name_cstrs.data(), input_values.data(), input_values.size(),
+                               output_name_cstrs.data(), output_name_cstrs.size());
+  }
+
+  // measure runs
+  run_result.run_durations.reserve(run_config.num_iterations);
+  for (size_t i = 0; i < run_config.num_iterations; ++i) {
+    timer.Reset();
+    auto outputs = session.Run(run_options,
+                               input_name_cstrs.data(), input_values.data(), input_values.size(),
+                               output_name_cstrs.data(), output_name_cstrs.size());
+    run_result.run_durations.push_back(timer.Elapsed());
+  }
+
+  return run_result;
+}
+
+std::string GetRunSummary(const RunConfig& run_config, const RunResult& run_result) {
+  auto to_display_duration = []<typename Rep, typename Period>(std::chrono::duration<Rep, Period> d) {
+    using DisplayPeriod = std::chrono::microseconds::period;
+    using DisplayDuration = std::chrono::duration<Rep, DisplayPeriod>;
+    return std::chrono::duration_cast<DisplayDuration>(d);
+  };
+
+  const auto model_path = std::filesystem::path{run_config.model_path};
+
+  const auto stats = ComputeRunResultStats(run_result);
+
+  const auto summary = std::format(
+      "Model: {}\n"
+      "Load time: {}\n"
+      "N (number of runs): {}\n"
+      "Latency\n"
+      "  avg: {}\n"
+      "  p50: {}\n"
+      "  p90: {}\n"
+      "  p99: {}\n"
+      "  min: {}\n"
+      "  max: {}\n",
+      model_path.filename().string(),
+      to_display_duration(run_result.load_duration),
+      stats.n,
+      to_display_duration(stats.average),
+      to_display_duration(stats.p50),
+      to_display_duration(stats.p90),
+      to_display_duration(stats.p99),
+      to_display_duration(stats.min),
+      to_display_duration(stats.max));
+
+  return summary;
+}
+
+}  // namespace model_runner

--- a/mobile/examples/model_tester/ios/ModelTester/ModelRunner/model_runner_objc_wrapper.h
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelRunner/model_runner_objc_wrapper.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+#include <stdint.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class is an Objective-C wrapper around the C++ model runner functionality.
+ */
+@interface ModelRunner : NSObject
+
++ (nullable NSString*)runWithModelPath:(NSString*)modelPath
+                         numIterations:(uint32_t)numIterations
+                                 error:(NSError**)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/mobile/examples/model_tester/ios/ModelTester/ModelRunner/model_runner_objc_wrapper.mm
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelRunner/model_runner_objc_wrapper.mm
@@ -1,0 +1,34 @@
+#import "model_runner_objc_wrapper.h"
+
+#include "model_runner.h"
+
+@implementation ModelRunner
+
++ (nullable NSString*)runWithModelPath:(NSString*)modelPath
+                         numIterations:(uint32_t)numIterations
+                                 error:(NSError**)error {
+  try {
+    model_runner::RunConfig config{};
+    config.model_path = modelPath.UTF8String;
+    config.num_iterations = numIterations;
+    config.num_warmup_iterations = 1;
+
+    auto result = model_runner::Run(config);
+
+    auto summary = model_runner::GetRunSummary(config, result);
+
+    return [NSString stringWithUTF8String:summary.c_str()];
+  } catch (const std::exception& e) {
+    if (error) {
+      NSString* description = [NSString stringWithCString:e.what()
+                                                 encoding:NSUTF8StringEncoding];
+
+      *error = [NSError errorWithDomain:@"ModelRunner"
+                                   code:0
+                               userInfo:@{NSLocalizedDescriptionKey : description}];
+    }
+    return nil;
+  }
+}
+
+@end

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester-Bridging-Header.h
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "model_runner_objc_wrapper.h"

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.pbxproj
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.pbxproj
@@ -1,0 +1,614 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2E163DAB2DCBE38900B4ED4A /* model_runner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E163DAA2DCBE38900B4ED4A /* model_runner.cpp */; };
+		2E163DD22DCBEC9F00B4ED4A /* model_runner_objc_wrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E163DD12DCBEC9200B4ED4A /* model_runner_objc_wrapper.mm */; };
+		2E163DD82DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx in Resources */ = {isa = PBXBuildFile; fileRef = 2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */; };
+		2E163DDA2DCC3DC600B4ED4A /* mobilenetv2-12.onnx in Resources */ = {isa = PBXBuildFile; fileRef = 2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		2E163D6D2DCBDF6B00B4ED4A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E163D542DCBDF6400B4ED4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2E163D5B2DCBDF6400B4ED4A;
+			remoteInfo = ModelTester;
+		};
+		2E163D772DCBDF6B00B4ED4A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E163D542DCBDF6400B4ED4A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2E163D5B2DCBDF6400B4ED4A;
+			remoteInfo = ModelTester;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		2E163D5C2DCBDF6400B4ED4A /* ModelTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ModelTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E163D6C2DCBDF6B00B4ED4A /* ModelTesterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ModelTesterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E163D762DCBDF6B00B4ED4A /* ModelTesterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ModelTesterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E163DAA2DCBE38900B4ED4A /* model_runner.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = model_runner.cpp; path = ../../common/model_runner.cpp; sourceTree = SOURCE_ROOT; };
+		2E163DAC2DCBE3AE00B4ED4A /* model_runner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = model_runner.h; path = ../../common/include/model_runner.h; sourceTree = SOURCE_ROOT; };
+		2E163DCF2DCBE98F00B4ED4A /* ModelTester-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ModelTester-Bridging-Header.h"; sourceTree = "<group>"; };
+		2E163DD02DCBEB0900B4ED4A /* model_runner_objc_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = model_runner_objc_wrapper.h; sourceTree = "<group>"; };
+		2E163DD12DCBEC9200B4ED4A /* model_runner_objc_wrapper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = model_runner_objc_wrapper.mm; sourceTree = "<group>"; };
+		2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = ssd_mobilenet_v1.onnx; sourceTree = "<group>"; };
+		2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mobilenetv2-12.onnx"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		2E163D5E2DCBDF6400B4ED4A /* ModelTester */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ModelTester;
+			sourceTree = "<group>";
+		};
+		2E163D6F2DCBDF6B00B4ED4A /* ModelTesterTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ModelTesterTests;
+			sourceTree = "<group>";
+		};
+		2E163D792DCBDF6B00B4ED4A /* ModelTesterUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ModelTesterUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2E163D592DCBDF6400B4ED4A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D692DCBDF6B00B4ED4A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D732DCBDF6B00B4ED4A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2E163D532DCBDF6400B4ED4A = {
+			isa = PBXGroup;
+			children = (
+				2E163DD72DCC23E500B4ED4A /* model */,
+				2E163DAD2DCBE3BC00B4ED4A /* ModelRunner */,
+				2E163D5E2DCBDF6400B4ED4A /* ModelTester */,
+				2E163D6F2DCBDF6B00B4ED4A /* ModelTesterTests */,
+				2E163D792DCBDF6B00B4ED4A /* ModelTesterUITests */,
+				2E163D5D2DCBDF6400B4ED4A /* Products */,
+				78FD58CC2213875ECC5EDF6B /* Pods */,
+				2E163DCF2DCBE98F00B4ED4A /* ModelTester-Bridging-Header.h */,
+			);
+			sourceTree = "<group>";
+		};
+		2E163D5D2DCBDF6400B4ED4A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2E163D5C2DCBDF6400B4ED4A /* ModelTester.app */,
+				2E163D6C2DCBDF6B00B4ED4A /* ModelTesterTests.xctest */,
+				2E163D762DCBDF6B00B4ED4A /* ModelTesterUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2E163DAD2DCBE3BC00B4ED4A /* ModelRunner */ = {
+			isa = PBXGroup;
+			children = (
+				2E163DD12DCBEC9200B4ED4A /* model_runner_objc_wrapper.mm */,
+				2E163DD02DCBEB0900B4ED4A /* model_runner_objc_wrapper.h */,
+				2E163DAC2DCBE3AE00B4ED4A /* model_runner.h */,
+				2E163DAA2DCBE38900B4ED4A /* model_runner.cpp */,
+			);
+			path = ModelRunner;
+			sourceTree = "<group>";
+		};
+		2E163DD72DCC23E500B4ED4A /* model */ = {
+			isa = PBXGroup;
+			children = (
+				2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */,
+				2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */,
+			);
+			path = model;
+			sourceTree = "<group>";
+		};
+		78FD58CC2213875ECC5EDF6B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2E163D5B2DCBDF6400B4ED4A /* ModelTester */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E163D802DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTester" */;
+			buildPhases = (
+				2E163D582DCBDF6400B4ED4A /* Sources */,
+				2E163D592DCBDF6400B4ED4A /* Frameworks */,
+				2E163D5A2DCBDF6400B4ED4A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				2E163D5E2DCBDF6400B4ED4A /* ModelTester */,
+			);
+			name = ModelTester;
+			productName = ModelTester;
+			productReference = 2E163D5C2DCBDF6400B4ED4A /* ModelTester.app */;
+			productType = "com.apple.product-type.application";
+		};
+		2E163D6B2DCBDF6B00B4ED4A /* ModelTesterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E163D832DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTesterTests" */;
+			buildPhases = (
+				2E163D682DCBDF6B00B4ED4A /* Sources */,
+				2E163D692DCBDF6B00B4ED4A /* Frameworks */,
+				2E163D6A2DCBDF6B00B4ED4A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2E163D6E2DCBDF6B00B4ED4A /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				2E163D6F2DCBDF6B00B4ED4A /* ModelTesterTests */,
+			);
+			name = ModelTesterTests;
+			productName = ModelTesterTests;
+			productReference = 2E163D6C2DCBDF6B00B4ED4A /* ModelTesterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		2E163D752DCBDF6B00B4ED4A /* ModelTesterUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2E163D862DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTesterUITests" */;
+			buildPhases = (
+				2E163D722DCBDF6B00B4ED4A /* Sources */,
+				2E163D732DCBDF6B00B4ED4A /* Frameworks */,
+				2E163D742DCBDF6B00B4ED4A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2E163D782DCBDF6B00B4ED4A /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				2E163D792DCBDF6B00B4ED4A /* ModelTesterUITests */,
+			);
+			name = ModelTesterUITests;
+			productName = ModelTesterUITests;
+			productReference = 2E163D762DCBDF6B00B4ED4A /* ModelTesterUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2E163D542DCBDF6400B4ED4A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					2E163D5B2DCBDF6400B4ED4A = {
+						CreatedOnToolsVersion = 16.0;
+						LastSwiftMigration = 1600;
+					};
+					2E163D6B2DCBDF6B00B4ED4A = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 2E163D5B2DCBDF6400B4ED4A;
+					};
+					2E163D752DCBDF6B00B4ED4A = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 2E163D5B2DCBDF6400B4ED4A;
+					};
+				};
+			};
+			buildConfigurationList = 2E163D572DCBDF6400B4ED4A /* Build configuration list for PBXProject "ModelTester" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2E163D532DCBDF6400B4ED4A;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 2E163D5D2DCBDF6400B4ED4A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2E163D5B2DCBDF6400B4ED4A /* ModelTester */,
+				2E163D6B2DCBDF6B00B4ED4A /* ModelTesterTests */,
+				2E163D752DCBDF6B00B4ED4A /* ModelTesterUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2E163D5A2DCBDF6400B4ED4A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2E163DD82DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx in Resources */,
+				2E163DDA2DCC3DC600B4ED4A /* mobilenetv2-12.onnx in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D6A2DCBDF6B00B4ED4A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D742DCBDF6B00B4ED4A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2E163D582DCBDF6400B4ED4A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2E163DAB2DCBE38900B4ED4A /* model_runner.cpp in Sources */,
+				2E163DD22DCBEC9F00B4ED4A /* model_runner_objc_wrapper.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D682DCBDF6B00B4ED4A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E163D722DCBDF6B00B4ED4A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2E163D6E2DCBDF6B00B4ED4A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2E163D5B2DCBDF6400B4ED4A /* ModelTester */;
+			targetProxy = 2E163D6D2DCBDF6B00B4ED4A /* PBXContainerItemProxy */;
+		};
+		2E163D782DCBDF6B00B4ED4A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2E163D5B2DCBDF6400B4ED4A /* ModelTester */;
+			targetProxy = 2E163D772DCBDF6B00B4ED4A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		2E163D7E2DCBDF6B00B4ED4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		2E163D7F2DCBDF6B00B4ED4A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2E163D812DCBDF6B00B4ED4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ModelTester/Preview Content\"";
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTester;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "ModelTester-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2E163D822DCBDF6B00B4ED4A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ModelTester/Preview Content\"";
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTester;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "ModelTester-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		2E163D842DCBDF6B00B4ED4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ModelTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ModelTester";
+			};
+			name = Debug;
+		};
+		2E163D852DCBDF6B00B4ED4A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTesterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ModelTester.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ModelTester";
+			};
+			name = Release;
+		};
+		2E163D872DCBDF6B00B4ED4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTesterUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ModelTester;
+			};
+			name = Debug;
+		};
+		2E163D882DCBDF6B00B4ED4A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onnxruntime.example.ModelTesterUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ModelTester;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2E163D572DCBDF6400B4ED4A /* Build configuration list for PBXProject "ModelTester" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2E163D7E2DCBDF6B00B4ED4A /* Debug */,
+				2E163D7F2DCBDF6B00B4ED4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2E163D802DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTester" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2E163D812DCBDF6B00B4ED4A /* Debug */,
+				2E163D822DCBDF6B00B4ED4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2E163D832DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTesterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2E163D842DCBDF6B00B4ED4A /* Debug */,
+				2E163D852DCBDF6B00B4ED4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2E163D862DCBDF6B00B4ED4A /* Build configuration list for PBXNativeTarget "ModelTesterUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2E163D872DCBDF6B00B4ED4A /* Debug */,
+				2E163D882DCBDF6B00B4ED4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2E163D542DCBDF6400B4ED4A /* Project object */;
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.pbxproj
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.pbxproj
@@ -9,8 +9,7 @@
 /* Begin PBXBuildFile section */
 		2E163DAB2DCBE38900B4ED4A /* model_runner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E163DAA2DCBE38900B4ED4A /* model_runner.cpp */; };
 		2E163DD22DCBEC9F00B4ED4A /* model_runner_objc_wrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E163DD12DCBEC9200B4ED4A /* model_runner_objc_wrapper.mm */; };
-		2E163DD82DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx in Resources */ = {isa = PBXBuildFile; fileRef = 2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */; };
-		2E163DDA2DCC3DC600B4ED4A /* mobilenetv2-12.onnx in Resources */ = {isa = PBXBuildFile; fileRef = 2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */; };
+		2E5D16F52DCD83DE0097F05B /* model.onnx in Resources */ = {isa = PBXBuildFile; fileRef = 2E5D16F42DCD83DE0097F05B /* model.onnx */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,8 +38,7 @@
 		2E163DCF2DCBE98F00B4ED4A /* ModelTester-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ModelTester-Bridging-Header.h"; sourceTree = "<group>"; };
 		2E163DD02DCBEB0900B4ED4A /* model_runner_objc_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = model_runner_objc_wrapper.h; sourceTree = "<group>"; };
 		2E163DD12DCBEC9200B4ED4A /* model_runner_objc_wrapper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = model_runner_objc_wrapper.mm; sourceTree = "<group>"; };
-		2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = ssd_mobilenet_v1.onnx; sourceTree = "<group>"; };
-		2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mobilenetv2-12.onnx"; sourceTree = "<group>"; };
+		2E5D16F42DCD83DE0097F05B /* model.onnx */ = {isa = PBXFileReference; lastKnownFileType = file; path = model.onnx; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -130,8 +128,7 @@
 		2E163DD72DCC23E500B4ED4A /* model */ = {
 			isa = PBXGroup;
 			children = (
-				2E163DD92DCC3DC600B4ED4A /* mobilenetv2-12.onnx */,
-				2E163DD62DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx */,
+				2E5D16F42DCD83DE0097F05B /* model.onnx */,
 			);
 			path = model;
 			sourceTree = "<group>";
@@ -258,8 +255,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2E163DD82DCC23E500B4ED4A /* ssd_mobilenet_v1.onnx in Resources */,
-				2E163DDA2DCC3DC600B4ED4A /* mobilenetv2-12.onnx in Resources */,
+				2E5D16F52DCD83DE0097F05B /* model.onnx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/Contents.json
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/ContentView.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
     DispatchQueue.global().async {
       var output: String
       do {
-        guard let modelPath = Bundle.main.path(forResource: "mobilenetv2-12", ofType: "onnx") else {
+        guard let modelPath = Bundle.main.path(forResource: "model", ofType: "onnx") else {
           throw ModelTesterError.runtimeError(msg: "Failed to find model file path.")
         }
 

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/ContentView.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/ContentView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+enum ModelTesterError: Error {
+  case runtimeError(msg: String)
+}
+
+struct ContentView: View {
+  @State private var runResultMessage: String = ""
+  @State private var isRunning: Bool = false
+  @State private var numIterations: UInt32 = 10
+
+  private func Run() {
+    isRunning = true
+
+    DispatchQueue.global().async {
+      var output: String
+      do {
+        guard let modelPath = Bundle.main.path(forResource: "mobilenetv2-12", ofType: "onnx") else {
+          throw ModelTesterError.runtimeError(msg: "Failed to find model file path.")
+        }
+
+        output = try ModelRunner.run(
+          withModelPath: modelPath,
+          numIterations: numIterations)
+      } catch {
+        output = "Error: \(error)"
+      }
+
+      print(output)
+      runResultMessage = output
+      isRunning = false
+    }
+  }
+
+  var body: some View {
+    VStack {
+      HStack {
+        Text("Iterations:")
+        TextField(
+          "", value: $numIterations,
+          format: IntegerFormatStyle<UInt32>.number
+        )
+        .keyboardType(.numberPad)
+      }
+
+      Button(action: Run) { Text("Run") }
+        .disabled(isRunning)
+
+      Text(runResultMessage)
+        .font(.body.monospaced())
+    }
+    .padding()
+  }
+}
+
+#Preview{
+  ContentView()
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/ModelTesterApp.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/ModelTesterApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ModelTesterApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTester/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTester/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTesterTests/ModelTesterTests.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTesterTests/ModelTesterTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+@testable import ModelTester
+
+final class ModelTesterTests: XCTestCase {
+
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+  }
+
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+
+  func testExample() throws {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // Any test you write for XCTest can be annotated as throws and async.
+    // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+    // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+  }
+
+  func testPerformanceExample() throws {
+    // This is an example of a performance test case.
+    self.measure {
+      // Put the code you want to measure the time of here.
+    }
+  }
+
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTesterUITests/ModelTesterUITests.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTesterUITests/ModelTesterUITests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+final class ModelTesterUITests: XCTestCase {
+
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    continueAfterFailure = false
+
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+  }
+
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+
+  @MainActor
+  func testExample() throws {
+    // UI tests must launch the application that they test.
+    let app = XCUIApplication()
+    app.launch()
+
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+  }
+
+  @MainActor
+  func testLaunchPerformance() throws {
+    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // This measures how long it takes to launch your application.
+      measure(metrics: [XCTApplicationLaunchMetric()]) {
+        XCUIApplication().launch()
+      }
+    }
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/ModelTesterUITests/ModelTesterUITestsLaunchTests.swift
+++ b/mobile/examples/model_tester/ios/ModelTester/ModelTesterUITests/ModelTesterUITestsLaunchTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+final class ModelTesterUITestsLaunchTests: XCTestCase {
+
+  override class var runsForEachTargetApplicationUIConfiguration: Bool {
+    true
+  }
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  @MainActor
+  func testLaunch() throws {
+    let app = XCUIApplication()
+    app.launch()
+
+    // Insert steps here to perform after app launch but before taking a screenshot,
+    // such as logging into a test account or navigating somewhere in the app
+
+    let attachment = XCTAttachment(screenshot: app.screenshot())
+    attachment.name = "Launch Screen"
+    attachment.lifetime = .keepAlways
+    add(attachment)
+  }
+}

--- a/mobile/examples/model_tester/ios/ModelTester/Podfile
+++ b/mobile/examples/model_tester/ios/ModelTester/Podfile
@@ -1,0 +1,20 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '16.0'
+
+target 'ModelTester' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for ModelTester
+  pod "onnxruntime-c"
+
+  target 'ModelTesterTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+  target 'ModelTesterUITests' do
+    # Pods for testing
+  end
+
+end

--- a/mobile/examples/model_tester/ios/ModelTester/model/readme.md
+++ b/mobile/examples/model_tester/ios/ModelTester/model/readme.md
@@ -1,0 +1,1 @@
+Add a model here and name it model.onnx.

--- a/mobile/examples/model_tester/ios/ModelTester/readme.md
+++ b/mobile/examples/model_tester/ios/ModelTester/readme.md
@@ -1,0 +1,11 @@
+This is a basic app that runs an arbitrary ONNX model. It can measure the model's performance.
+
+# Set Up Instructions
+
+Copy an ONNX model to `model/model.onnx`.
+
+Install the CocoaPods dependencies. From this directory, run `pod install`.
+
+Open the xcworkspace file. From this directory, run `open ModelTester.xcworkspace`.
+
+Build and run the ModelTester app from Xcode.

--- a/mobile/examples/model_tester/readme.md
+++ b/mobile/examples/model_tester/readme.md
@@ -1,0 +1,5 @@
+This directory contains example code for apps that can be used to run a model with onnxruntime. They can be used for basic performance testing.
+
+- `common/` contains common, cross-platform, code.
+- `ios/` contains an example iOS app.
+


### PR DESCRIPTION
Add iOS model tester app for measuring performance of a model.

There is also some cross-platform native code in `mobile/examples/model_tester/common` that can hopefully be reused in other contexts, such as an Android app.