### PR TITLE
[Plugin EP] Add python example for how to run a plugin EP

### DIFF
--- a/python/plugin_EP/README.md
+++ b/python/plugin_EP/README.md
@@ -1,0 +1,4 @@
+# Running Inference with a Plugin EP
+## Prerequisites
+- A dynamic/shared EP library that exports the functions `CreateEpFactories()` and `ReleaseEpFactory()`.
+- ONNX Runtime built as a shared library (e.g., `onnxruntime.dll` on Windows or `libonnxruntime.so` on Linux), since the EP library relies on the public ORT C API (which is ABI-stable) to interact with ONNX Runtime. 

--- a/python/plugin_EP/README.md
+++ b/python/plugin_EP/README.md
@@ -5,18 +5,43 @@
 
 ## Run Inference with explicit OrtEpDevice(s)
 
-Please see `plugin_ep_inference.py` for details
-1. Register plugin EP library with ONNX Runtime via `onnxruntime.register_execution_provider_library()`
-2. Find the OrtEpDevice for that ep name via `onnxruntime.get_ep_devices()`
-3. Append the ep to ORT session option via `sess_options.add_provider_for_devices`
-4. Create ORT session with the ep
-5. Run ORT session
-6. Unregister plugin EP library via `onnxruntime.unregister_execution_provider_library()`
+Please see `plugin_ep_inference.py` for a full example.
+1. Register plugin EP library with ONNX Runtime
+   ````python
+   onnxruntime.register_execution_provider_library("plugin_ep.so")
+   ````
+2. Find the OrtEpDevice for that EP
+   ````Python
+   ep_device = onnxruntime.get_ep_devices()
+   for ep_device in ep_devices:
+       if ep_device.ep_name == ep_name:
+           target_ep_device = ep_device
+    ````
+3. Append the EP to ORT session option
+    ````Python
+    sess_options.add_provider_for_devices([target_ep_device], {})
+    ````
+5. Create ORT session with the EP
+    ```Python
+    sess = onnxrt.InferenceSession("/path/to/model", sess_options=sess_options)
+    ````
+6. Run ORT session
+   ````Python
+   res = sess.run([], {input_name: x})
+   ````
+7. Unregister plugin EP library
+    ```Python
+   onnxruntime.unregister_execution_provider_library(ep_registration_name)
+   ````
 
 
  ## Run Inference with automatic EP selection
- The workflow is the same as above except #2 and #3 step and should be replaced with `sess_options.set_provider_selection_policy(policy)`,
- "policy" could be:
+ The workflow is the same as above except for step 2 and 3.
+ Instead, set the selection policy directly 
+ ````Python
+ sess_options.set_provider_selection_policy(policy)
+ ````
+ Available "policy":
  - `onnxruntime.OrtExecutionProviderDevicePolicy_DEFAULT`
  - `onnxruntime.OrtExecutionProviderDevicePolicy_PREFER_CPU`
  - `onnxruntime.OrtExecutionProviderDevicePolicy_PREFER_NPU`
@@ -25,4 +50,7 @@ Please see `plugin_ep_inference.py` for details
  - `onnxruntime.OrtExecutionProviderDevicePolicy_MAX_EFFICIENCY`
  - `onnxruntime.OrtExecutionProviderDevicePolicy_MIN_OVERALL_POWER`
 
- 
+ ## Note
+ For additional APIs and details on plugin EP usage, see the official documentation:
+ https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries.html#using-a-plugin-ep-library
+

--- a/python/plugin_EP/README.md
+++ b/python/plugin_EP/README.md
@@ -2,3 +2,27 @@
 ## Prerequisites
 - A dynamic/shared EP library that exports the functions `CreateEpFactories()` and `ReleaseEpFactory()`.
 - ONNX Runtime built as a shared library (e.g., `onnxruntime.dll` on Windows or `libonnxruntime.so` on Linux), since the EP library relies on the public ORT C API (which is ABI-stable) to interact with ONNX Runtime. 
+
+## Run Inference with explicit OrtEpDevice(s)
+
+Please see `plugin_ep_inference.py` for details
+1. Register plugin EP library with ONNX Runtime via `onnxruntime.register_execution_provider_library()`
+2. Find the OrtEpDevice for that ep name via `onnxruntime.get_ep_devices()`
+3. Append the ep to ORT session option via `sess_options.add_provider_for_devices`
+4. Create ORT session with the ep
+5. Run ORT session
+6. Unregister plugin EP library via `onnxruntime.unregister_execution_provider_library()`
+
+
+ ## Run Inference with automatic EP selection
+ The workflow is the same as above except #2 and #3 step and should be replaced with `sess_options.set_provider_selection_policy(policy)`,
+ "policy" could be:
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_DEFAULT`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_PREFER_CPU`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_PREFER_NPU`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_PREFER_GPU`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_MAX_PERFORMANCE`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_MAX_EFFICIENCY`
+ - `onnxruntime.OrtExecutionProviderDevicePolicy_MIN_OVERALL_POWER`
+
+ 

--- a/python/plugin_EP/plugin_ep_inference.py
+++ b/python/plugin_EP/plugin_ep_inference.py
@@ -44,3 +44,8 @@ np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 # Unregister the library using the application-specified registration name.
 # Must only unregister a library after all sessions that use the library have been released.
 onnxrt.unregister_execution_provider_library(ep_registration_name)
+
+
+# Note:
+# The mul_1.onnx can be found here:
+# https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/test/testdata/mul_1.onnx

--- a/python/plugin_EP/plugin_ep_inference.py
+++ b/python/plugin_EP/plugin_ep_inference.py
@@ -1,0 +1,31 @@
+import onnxruntime as onnxrt
+import numpy as np
+                                                                                                                                                                                                                                                                      
+ep_lib_path = "C:\\path\\to\\plugin_trt_ep\\TensorRTEp.dll"
+ep_name = "TensorRTEp"
+ep_registration_name = ep_name
+
+onnxrt.register_execution_provider_library(ep_registration_name, ep_lib_path)
+
+ep_devices = onnxrt.get_ep_devices()
+trt_ep_device = None
+for ep_device in ep_devices:
+    if ep_device.ep_name == ep_name:
+        trt_ep_device = ep_device
+
+assert trt_ep_device != None                                                                                                                                                                                                                                                            
+sess_options = onnxrt.SessionOptions()
+sess_options.add_provider_for_devices([trt_ep_device], {'trt_engine_cache_enable': '1'})
+
+assert sess_options.has_providers() == True
+
+# Run sample model and check output
+sess = onnxrt.InferenceSession("C:\\modles\\mul_1.onnx", sess_options=sess_options)
+
+x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+input_name = sess.get_inputs()[0].name
+res = sess.run([], {input_name: x})
+output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
+np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
+
+onnxrt.unregister_execution_provider_library(ep_registration_name)

--- a/python/plugin_EP/plugin_ep_inference.py
+++ b/python/plugin_EP/plugin_ep_inference.py
@@ -1,31 +1,46 @@
 import onnxruntime as onnxrt
 import numpy as np
-                                                                                                                                                                                                                                                                      
-ep_lib_path = "C:\\path\\to\\plugin_trt_ep\\TensorRTEp.dll"
-ep_name = "TensorRTEp"
-ep_registration_name = ep_name
 
+# Path to the plugin EP library
+ep_lib_path = "C:\\path\\to\\plugin_trt_ep\\TensorRTEp.dll"
+# Registration name can be anything the application chooses
+ep_registration_name = "TensorRTEp"
+# EP name should match the name assigned by the EP factory when creating the EP (i.e., in the implementation of OrtEP::CreateEp)
+ep_name = ep_registration_name
+
+# Register plugin EP library with ONNX Runtime
 onnxrt.register_execution_provider_library(ep_registration_name, ep_lib_path)
 
+#
+# Create ORT session with explicit OrtEpDevice(s)
+#
+
+# Find the OrtEpDevice for "TensorRTEp"
 ep_devices = onnxrt.get_ep_devices()
 trt_ep_device = None
 for ep_device in ep_devices:
     if ep_device.ep_name == ep_name:
         trt_ep_device = ep_device
 
-assert trt_ep_device != None                                                                                                                                                                                                                                                            
+assert trt_ep_device != None
+
 sess_options = onnxrt.SessionOptions()
+
+# Equivalent to the C API's SessionOptionsAppendExecutionProvider_V2 that appends "TensorRTEp" to ORT session option
 sess_options.add_provider_for_devices([trt_ep_device], {'trt_engine_cache_enable': '1'})
 
 assert sess_options.has_providers() == True
 
-# Run sample model and check output
+# Create ORT session with "TensorRTEp" plugin EP
 sess = onnxrt.InferenceSession("C:\\modles\\mul_1.onnx", sess_options=sess_options)
 
+# Run sample model and check output
 x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
 input_name = sess.get_inputs()[0].name
 res = sess.run([], {input_name: x})
 output_expected = np.array([[1.0, 4.0], [9.0, 16.0], [25.0, 36.0]], dtype=np.float32)
 np.testing.assert_allclose(output_expected, res[0], rtol=1e-05, atol=1e-08)
 
+# Unregister the library using the application-specified registration name.
+# Must only unregister a library after all sessions that use the library have been released.
 onnxrt.unregister_execution_provider_library(ep_registration_name)


### PR DESCRIPTION
We have a [documentation ](https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries.html#using-a-plugin-ep-library)for showing how to use C++ API to run a plugin EP.
Add an example for python usage.