### PR TITLE
[Plugin TRT EP] Add MemcpyToHost and MemcpyFromHost kernel implementations

### DIFF
--- a/plugin_execution_providers/tensorrt/CMakeLists.txt
+++ b/plugin_execution_providers/tensorrt/CMakeLists.txt
@@ -30,7 +30,8 @@ endif()
 add_definitions(-DONNX_NAMESPACE=onnx)
 add_definitions(-DONNX_ML)
 add_definitions(-DNOMINMAX)
-file(GLOB tensorrt_src "./src/*.cc" "./src/utils/*.cc" "./src/cuda/unary_elementwise_ops_impl.cu" "./src/*.h")
+
+file(GLOB tensorrt_src "./src/*.cc" "./src/kernels/*.cc" "./src/utils/*.cc" "./src/cuda/unary_elementwise_ops_impl.cu" "./src/*.h" "./src/kernels/*.h")
 add_library(TensorRTEp SHARED ${tensorrt_src})
 
 set_onnxruntime_paths(

--- a/plugin_execution_providers/tensorrt/CMakeLists.txt
+++ b/plugin_execution_providers/tensorrt/CMakeLists.txt
@@ -31,7 +31,14 @@ add_definitions(-DONNX_NAMESPACE=onnx)
 add_definitions(-DONNX_ML)
 add_definitions(-DNOMINMAX)
 
-file(GLOB tensorrt_src "./src/*.cc" "./src/kernels/*.cc" "./src/utils/*.cc" "./src/cuda/unary_elementwise_ops_impl.cu" "./src/*.h" "./src/kernels/*.h")
+file(GLOB tensorrt_src 
+  "./src/*.cc"
+  "./src/kernels/*.cc"
+  "./src/utils/*.cc"
+  "./src/cuda/unary_elementwise_ops_impl.cu"
+  "./src/*.h"
+  "./src/kernels/*.h"
+)
 add_library(TensorRTEp SHARED ${tensorrt_src})
 
 set_onnxruntime_paths(

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "memcpy.h"
+#include "utils.h"
+#include <cuda_runtime.h>
+
+namespace trt_ep {
+
+// static
+OrtStatus* MemcpyFromHost::Create(const OrtKernelInfo* info, void* state,
+                                  /*out*/ OrtKernelImpl*& kernel) {
+  try {
+    auto new_kernel = std::make_unique<MemcpyFromHost>(info, state, PrivateTag{});
+    kernel = new_kernel.release();
+    return nullptr;
+  } catch (const Ort::Exception& ex) {
+    Ort::Status status(ex);
+    return status.release();
+  } catch (const std::exception& ex) {
+    Ort::Status status(ex.what(), ORT_EP_FAIL);
+    return status.release();
+  }
+}
+
+MemcpyFromHost::MemcpyFromHost(const OrtKernelInfo* info, void* state, PrivateTag)
+    : OrtKernelImpl {}, info_(info), state_(state) {
+  ort_version_supported = ORT_API_VERSION;
+  Compute = ComputeImpl;
+  Release = ReleaseImpl;
+}
+
+OrtStatus* MemcpyFromHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept {
+  try {
+    const OrtApi& ort_api = Ort::GetApi();
+    const OrtValue* input_tensor = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetInput(kernel_ctx, 0, &input_tensor));
+
+    // Get tensor shape and type
+    OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+    RETURN_IF_ERROR(ort_api.GetTensorTypeAndShape(input_tensor, &tensor_info));
+
+    size_t element_count = 0;
+    RETURN_IF_ERROR(ort_api.GetTensorShapeElementCount(tensor_info, &element_count));
+
+    ONNXTensorElementDataType element_type;
+    RETURN_IF_ERROR(ort_api.GetTensorElementType(tensor_info, &element_type));
+
+    size_t num_dims = 0;
+    RETURN_IF_ERROR(ort_api.GetDimensionsCount(tensor_info, &num_dims));
+
+    std::vector<int64_t> dims(num_dims);
+    RETURN_IF_ERROR(ort_api.GetDimensions(tensor_info, dims.data(), num_dims));
+    ort_api.ReleaseTensorTypeAndShapeInfo(tensor_info);
+
+    // Get output tensor
+    OrtValue* output_tensor = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetOutput(kernel_ctx, 0, dims.data(), num_dims, &output_tensor));
+
+    // Get data pointers
+    const void* input_data = nullptr;
+    void* output_data = nullptr;
+    RETURN_IF_ERROR(ort_api.GetTensorData(input_tensor, &input_data));
+    RETURN_IF_ERROR(ort_api.GetTensorMutableData(output_tensor, &output_data));
+
+    // Calculate size in bytes
+    size_t bytes = 0;
+    RETURN_IF_ERROR(ort_api.GetTensorSizeInBytes(input_tensor, &bytes));
+
+    // Get CUDA stream from kernel context
+    void* cuda_stream = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetGPUComputeStream(kernel_ctx, &cuda_stream));
+    cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
+
+    // Copy from host (CPU) to device (GPU) asynchronously
+    cudaError_t cuda_err = cudaMemcpyAsync(output_data, input_data, bytes, cudaMemcpyHostToDevice, stream);
+    if (cuda_err != cudaSuccess) {
+      return ort_api.CreateStatus(ORT_EP_FAIL, cudaGetErrorString(cuda_err));
+    }
+
+    return nullptr;
+  } catch (const Ort::Exception& ex) {
+    Ort::Status status(ex);
+    return status.release();
+  } catch (const std::exception& ex) {
+    Ort::Status status(ex.what(), ORT_EP_FAIL);
+    return status.release();
+  }
+}
+
+// MemcpyToHost implementation
+
+// static
+OrtStatus* MemcpyToHost::Create(const OrtKernelInfo* info, void* state,
+                                /*out*/ OrtKernelImpl*& kernel) {
+  try {
+    auto new_kernel = std::make_unique<MemcpyToHost>(info, state, PrivateTag{});
+    kernel = new_kernel.release();
+    return nullptr;
+  } catch (const Ort::Exception& ex) {
+    Ort::Status status(ex);
+    return status.release();
+  } catch (const std::exception& ex) {
+    Ort::Status status(ex.what(), ORT_EP_FAIL);
+    return status.release();
+  }
+}
+
+MemcpyToHost::MemcpyToHost(const OrtKernelInfo* info, void* state, PrivateTag)
+    : OrtKernelImpl{}, info_(info), state_(state) {
+  ort_version_supported = ORT_API_VERSION;
+  Compute = ComputeImpl;
+  Release = ReleaseImpl;
+}
+
+OrtStatus* MemcpyToHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept {
+  try {
+    const OrtApi& ort_api = Ort::GetApi();
+    const OrtValue* input_tensor = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetInput(kernel_ctx, 0, &input_tensor));
+
+    // Get tensor shape and type
+    OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+    RETURN_IF_ERROR(ort_api.GetTensorTypeAndShape(input_tensor, &tensor_info));
+
+    size_t num_dims = 0;
+    RETURN_IF_ERROR(ort_api.GetDimensionsCount(tensor_info, &num_dims));
+
+    std::vector<int64_t> dims(num_dims);
+    RETURN_IF_ERROR(ort_api.GetDimensions(tensor_info, dims.data(), num_dims));
+    ort_api.ReleaseTensorTypeAndShapeInfo(tensor_info);
+
+    // Get output tensor
+    OrtValue* output_tensor = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetOutput(kernel_ctx, 0, dims.data(), num_dims, &output_tensor));
+
+    // Get data pointers
+    const void* input_data = nullptr;
+    void* output_data = nullptr;
+    RETURN_IF_ERROR(ort_api.GetTensorData(input_tensor, &input_data));
+    RETURN_IF_ERROR(ort_api.GetTensorMutableData(output_tensor, &output_data));
+
+    // Calculate size in bytes
+    size_t bytes = 0;
+    RETURN_IF_ERROR(ort_api.GetTensorSizeInBytes(input_tensor, &bytes));
+
+    // Get CUDA stream from kernel context
+    void* cuda_stream = nullptr;
+    RETURN_IF_ERROR(ort_api.KernelContext_GetGPUComputeStream(kernel_ctx, &cuda_stream));
+    cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
+
+    // Copy from device (GPU) to host (CPU) asynchronously
+    cudaError_t cuda_err = cudaMemcpyAsync(output_data, input_data, bytes, cudaMemcpyDeviceToHost, stream);
+    if (cuda_err != cudaSuccess) {
+      return ort_api.CreateStatus(ORT_EP_FAIL, cudaGetErrorString(cuda_err));
+    }
+
+    return nullptr;
+  } catch (const Ort::Exception& ex) {
+    Ort::Status status(ex);
+    return status.release();
+  } catch (const std::exception& ex) {
+    Ort::Status status(ex.what(), ORT_EP_FAIL);
+    return status.release();
+  }
+}
+
+ONNX_OPERATOR_KERNEL_EX(
+    MemcpyFromHost,
+    kOnnxDomain,
+    /*version*/ 1,  // Equivalent to start_version: 14, end_version: 14 (inclusive)
+    (Ort::KernelDefBuilder()
+         .SetInputMemType(0, OrtMemType::OrtMemTypeCPUInput)
+         .AddTypeConstraint("T", GetTensorType(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT))),
+    MemcpyFromHost)
+
+ONNX_OPERATOR_KERNEL_EX(
+    MemcpyToHost,
+    kOnnxDomain,
+    /*version*/ 1,  // Equivalent to start_version: 14, end_version: 14 (inclusive)
+    (Ort::KernelDefBuilder()
+         .SetOutputMemType(0, OrtMemType::OrtMemTypeCPUOutput)
+         .AddTypeConstraint("T", GetTensorType(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT))),
+    MemcpyToHost)
+
+}  // namespace trt_ep

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "memcpy.h"
 #include "utils.h"
+#include "memcpy.h"
 #include <cuda_runtime.h>
 
 namespace trt_ep {
@@ -16,13 +16,13 @@ OrtStatus* MemcpyKernelBase::CreateImpl(const OrtKernelInfo* info, void* state,
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status;
+    return status.release();
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status;
+    return status.release();
   } catch (...) {
     Ort::Status status("Unknown exception in MemcpyKernelBase::Create", ORT_EP_FAIL);
-    return status;
+    return status.release();
   }
 }
 
@@ -82,10 +82,10 @@ OrtStatus* MemcpyFromHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status;
+    return status.release();
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status;
+    return status.release();
   }
 }
 
@@ -134,10 +134,10 @@ OrtStatus* MemcpyToHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* 
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status;
+    return status.release();
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status;
+    return status.release();
   }
 }
 

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.cc
@@ -7,27 +7,28 @@
 
 namespace trt_ep {
 
-// static
-OrtStatus* MemcpyFromHost::Create(const OrtKernelInfo* info, void* state,
-                                  /*out*/ OrtKernelImpl*& kernel) {
+template <typename T>
+OrtStatus* MemcpyKernelBase::CreateImpl(const OrtKernelInfo* info, void* state,
+                                        /*out*/ OrtKernelImpl*& kernel) noexcept {
   try {
-    auto new_kernel = std::make_unique<MemcpyFromHost>(info, state, PrivateTag{});
-    kernel = new_kernel.release();
+    auto p = std::make_unique<T>(info, state, typename T::PrivateTag{});
+    kernel = p.release();
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status.release();
+    return status;
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status.release();
+    return status;
+  } catch (...) {
+    Ort::Status status("Unknown exception in MemcpyKernelBase::Create", ORT_EP_FAIL);
+    return status;
   }
 }
 
-MemcpyFromHost::MemcpyFromHost(const OrtKernelInfo* info, void* state, PrivateTag)
-    : OrtKernelImpl {}, info_(info), state_(state) {
-  ort_version_supported = ORT_API_VERSION;
-  Compute = ComputeImpl;
-  Release = ReleaseImpl;
+template <typename T>
+static void MemcpyKernelBase::ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
+  delete static_cast<T*>(this_ptr);
 }
 
 OrtStatus* MemcpyFromHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept {
@@ -81,36 +82,11 @@ OrtStatus* MemcpyFromHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status.release();
+    return status;
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status.release();
+    return status;
   }
-}
-
-// MemcpyToHost implementation
-
-// static
-OrtStatus* MemcpyToHost::Create(const OrtKernelInfo* info, void* state,
-                                /*out*/ OrtKernelImpl*& kernel) {
-  try {
-    auto new_kernel = std::make_unique<MemcpyToHost>(info, state, PrivateTag{});
-    kernel = new_kernel.release();
-    return nullptr;
-  } catch (const Ort::Exception& ex) {
-    Ort::Status status(ex);
-    return status.release();
-  } catch (const std::exception& ex) {
-    Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status.release();
-  }
-}
-
-MemcpyToHost::MemcpyToHost(const OrtKernelInfo* info, void* state, PrivateTag)
-    : OrtKernelImpl{}, info_(info), state_(state) {
-  ort_version_supported = ORT_API_VERSION;
-  Compute = ComputeImpl;
-  Release = ReleaseImpl;
 }
 
 OrtStatus* MemcpyToHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept {
@@ -158,10 +134,10 @@ OrtStatus* MemcpyToHost::ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* 
     return nullptr;
   } catch (const Ort::Exception& ex) {
     Ort::Status status(ex);
-    return status.release();
+    return status;
   } catch (const std::exception& ex) {
     Ort::Status status(ex.what(), ORT_EP_FAIL);
-    return status.release();
+    return status;
   }
 }
 

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ep_utils.h"
+
+namespace trt_ep {
+
+struct MemcpyFromHost : public OrtKernelImpl {
+ private:
+  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyFromHost::Create())
+                         // Need to make the constructor public for std::make_unique().
+ public:
+  static OrtStatus* Create(const OrtKernelInfo* info, void* state, /*out*/ OrtKernelImpl*& kernel);
+
+  MemcpyFromHost(const OrtKernelInfo* info, void* state, PrivateTag);
+
+  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
+  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
+    delete static_cast<MemcpyFromHost*>(this_ptr);
+  };
+
+ private:
+  const OrtKernelInfo* info_;
+  void* state_;  // Custom state passed from OrtEp
+};
+
+struct MemcpyToHost : public OrtKernelImpl {
+ private:
+  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyToHost::Create())
+                         // Need to make the constructor public for std::make_unique().
+ public:
+  static OrtStatus* Create(const OrtKernelInfo* info, void* state, /*out*/ OrtKernelImpl*& kernel);
+
+  MemcpyToHost(const OrtKernelInfo* info, void* state, PrivateTag);
+
+  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
+  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
+    delete static_cast<MemcpyToHost*>(this_ptr);
+  };
+
+ private:
+  const OrtKernelInfo* info_;
+  void* state_;  // Custom state passed from OrtEp
+};
+
+}

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "ep_utils.h"
+struct OrtKernelImpl;
+struct OrtKernelInfo;
+struct OrtKernelContext;
+struct OrtStatus;
 
 namespace trt_ep {
 

--- a/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
+++ b/plugin_execution_providers/tensorrt/src/kernels/memcpy.h
@@ -5,42 +5,73 @@
 
 namespace trt_ep {
 
-struct MemcpyFromHost : public OrtKernelImpl {
- private:
-  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyFromHost::Create())
-                         // Need to make the constructor public for std::make_unique().
- public:
-  static OrtStatus* Create(const OrtKernelInfo* info, void* state, /*out*/ OrtKernelImpl*& kernel);
+struct MemcpyKernelBase : public OrtKernelImpl {
+  // Base class for MemcpyFromHost and MemcpyToHost to share common code.
+ protected:
+  MemcpyKernelBase(const OrtKernelInfo* info, void* state) : OrtKernelImpl {}, info_(info), state_(state) {}
 
-  MemcpyFromHost(const OrtKernelInfo* info, void* state, PrivateTag);
+  template <typename T>
+  static OrtStatus* CreateImpl(const OrtKernelInfo* info, void* state, /*out*/ OrtKernelImpl*& kernel) noexcept;
 
-  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
-  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
-    delete static_cast<MemcpyFromHost*>(this_ptr);
-  };
+  template <typename T>
+  static void ReleaseImpl(OrtKernelImpl* this_ptr) noexcept;
 
- private:
   const OrtKernelInfo* info_;
   void* state_;  // Custom state passed from OrtEp
 };
 
-struct MemcpyToHost : public OrtKernelImpl {
+struct MemcpyFromHost : public MemcpyKernelBase {
  private:
-  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyToHost::Create())
+  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyFromHost::Create())
                          // Need to make the constructor public for std::make_unique().
+
+  // Allow base template helper to access PrivateTag
+  friend struct MemcpyKernelBase;
+
  public:
-  static OrtStatus* Create(const OrtKernelInfo* info, void* state, /*out*/ OrtKernelImpl*& kernel);
-
-  MemcpyToHost(const OrtKernelInfo* info, void* state, PrivateTag);
-
-  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
-  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
-    delete static_cast<MemcpyToHost*>(this_ptr);
+  MemcpyFromHost(const OrtKernelInfo* info, void* state, PrivateTag) : MemcpyKernelBase(info, state) {
+    ort_version_supported = ORT_API_VERSION;
+    Compute = ComputeImpl;
+    Release = ReleaseImpl;
   };
 
+  static OrtStatus* Create(const OrtKernelInfo* info, void* state,
+                           /*out*/ OrtKernelImpl*& kernel) noexcept {
+    return CreateImpl<MemcpyFromHost>(info, state, kernel);
+  }
+
+  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
+
+  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
+    MemcpyKernelBase::ReleaseImpl<MemcpyFromHost>(this_ptr);
+  };
+};
+
+struct MemcpyToHost : public MemcpyKernelBase {
  private:
-  const OrtKernelInfo* info_;
-  void* state_;  // Custom state passed from OrtEp
+  struct PrivateTag {};  // Used to prevent use of public constructor (use static MemcpyFromHost::Create())
+                         // Need to make the constructor public for std::make_unique().
+
+  // Allow base template helper to access PrivateTag
+  friend struct MemcpyKernelBase;
+
+ public:
+  MemcpyToHost(const OrtKernelInfo* info, void* state, PrivateTag) : MemcpyKernelBase(info, state) {
+    ort_version_supported = ORT_API_VERSION;
+    Compute = ComputeImpl;
+    Release = ReleaseImpl;
+  };
+
+  static OrtStatus* Create(const OrtKernelInfo* info, void* state,
+                           /*out*/ OrtKernelImpl*& kernel) noexcept {
+    return CreateImpl<MemcpyToHost>(info, state, kernel);
+  }
+
+  static OrtStatus* ORT_API_CALL ComputeImpl(OrtKernelImpl* this_ptr, OrtKernelContext* kernel_ctx) noexcept;
+
+  static void ORT_API_CALL ReleaseImpl(OrtKernelImpl* this_ptr) noexcept {
+    MemcpyKernelBase::ReleaseImpl<MemcpyToHost>(this_ptr);
+  };
 };
 
 }

--- a/plugin_execution_providers/tensorrt/src/kernels/utils.h
+++ b/plugin_execution_providers/tensorrt/src/kernels/utils.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "onnxruntime_cxx_api.h"
+
+namespace trt_ep {
+
+/// <summary>
+/// Gets an OrtDataType for a tensor type. Throws on error.
+/// </summary>
+/// <param name="elem_type"></param>
+/// <returns></returns>
+inline const OrtDataType* GetTensorType(ONNXTensorElementDataType elem_type) {
+  const OrtEpApi& ep_api = Ort::GetEpApi();
+  const OrtDataType* result = nullptr;
+
+  Ort::ThrowOnError(ep_api.GetTensorDataType(elem_type, &result));
+  return result;
+}
+
+/// <summary>
+/// Contains information to create a kernel: kernel definition, creation function + state.
+/// </summary>
+struct KernelCreateInfo {
+  KernelCreateInfo() = default;
+  KernelCreateInfo(Ort::KernelDef def, OrtKernelCreateFunc func, void* state)
+      : kernel_def{std::move(def)}, kernel_create_func{func}, kernel_create_func_state{state} {}
+
+  Ort::KernelDef kernel_def{nullptr};
+  OrtKernelCreateFunc kernel_create_func = nullptr;
+  void* kernel_create_func_state = nullptr;
+};
+
+using BuildKernelCreateInfoFn = OrtStatus* (*)(const char*, void*, KernelCreateInfo*);
+
+template <typename T>
+OrtStatus* BuildKernelCreateInfo(const char* ep_name, void* create_func_state, /*out*/ KernelCreateInfo* result);
+
+template <>
+inline OrtStatus* BuildKernelCreateInfo<void>(const char* /*ep_name*/, void* /*create_func_state*/,
+                                              /*out*/ KernelCreateInfo* result) {
+  result->kernel_def = Ort::KernelDef{nullptr};
+  result->kernel_create_func = nullptr;
+  result->kernel_create_func_state = nullptr;
+  return nullptr;
+}
+
+static constexpr const char* kOnnxDomain = "";
+
+// Naming convention for operator kernel classes with a start and end version range.
+#define ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(domain, startver, endver, name) \
+  example_ep_##name##_##domain##_ver##startver##_##endver
+
+// Naming convention for operator kernel classes for a single version
+#define ONNX_OPERATOR_KERNEL_CLASS_NAME(domain, version, name) \
+  ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(domain, version, version, name)
+
+// Defines a function of type BuildKernelCreateInfoFn for a kernel implementation with a start and end version range.
+#define ONNX_OPERATOR_VERSIONED_KERNEL_EX(name, domain, startver, endver, builder, kernel_class)    \
+  class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(domain, startver, endver, name);                  \
+  template <>                                                                                       \
+  OrtStatus*                                                                                        \
+  BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(domain, startver, endver, name)>( \
+      const char* ep_name,                                                                          \
+      void* create_kernel_state,                                                                    \
+      KernelCreateInfo* result) {                                                                   \
+    try {                                                                                           \
+      Ort::KernelDef kernel_def = builder.SetOperatorType(#name)                                    \
+                                      .SetDomain(domain)                                            \
+                                      .SetSinceVersion(startver, endver)                            \
+                                      .SetExecutionProvider(ep_name)                                \
+                                      .Build();                                                     \
+                                                                                                    \
+      auto kernel_create_func = [](void* state, const OrtKernelInfo* info,                          \
+                                   OrtKernelImpl** kernel_out) noexcept -> OrtStatus* {             \
+        RETURN_IF(kernel_out == nullptr,                                             \
+                  "OrtKernelCreateFunc received a NULL kernel_out argument");                       \
+                                                                                                    \
+        *kernel_out = nullptr;                                                                      \
+        RETURN_IF_ERROR(kernel_class::Create(info, state, *kernel_out));                  \
+        return nullptr;                                                                             \
+      };                                                                                            \
+                                                                                                    \
+      *result = KernelCreateInfo(std::move(kernel_def), kernel_create_func, create_kernel_state);   \
+    } catch (const Ort::Exception& ex) {                                                            \
+      Ort::Status status(ex);                                                                       \
+      return status.release();                                                                      \
+    } catch (const std::exception& ex) {                                                            \
+      Ort::Status status(ex.what(), ORT_EP_FAIL);                                                   \
+      return status.release();                                                                      \
+    }                                                                                               \
+    return nullptr;                                                                                 \
+  }
+
+// Defines a function of type BuildKernelCreateInfoFn for a kernel implementation with a start version.
+#define ONNX_OPERATOR_KERNEL_EX(name, domain, version, builder, kernel_class) \
+  ONNX_OPERATOR_VERSIONED_KERNEL_EX(name, domain, version, version, builder, kernel_class)
+}

--- a/plugin_execution_providers/tensorrt/src/kernels/utils.h
+++ b/plugin_execution_providers/tensorrt/src/kernels/utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "onnxruntime_cxx_api.h"
+#include "ep_utils.h"
 
 namespace trt_ep {
 

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
@@ -2330,6 +2330,19 @@ OrtStatus* ORT_API_CALL TensorrtExecutionProvider::CreateSyncStreamForDeviceImpl
   return nullptr;
 }
 
+/*static*/
+OrtStatus* ORT_API_CALL TensorrtExecutionProvider::GetKernelRegistryImpl(
+    _In_ OrtEp* this_ptr,
+    _Outptr_result_maybenull_ const OrtKernelRegistry** kernel_registry) noexcept {
+  TensorrtExecutionProvider* ep = static_cast<TensorrtExecutionProvider*>(this_ptr);
+
+  *kernel_registry = nullptr;
+
+  // Get the cached kernel registry from parent factory to avoid recreating the kernel registry for every EP instance.
+  RETURN_IF_ERROR(ep->factory_.GetKernelRegistryForEp(*ep, kernel_registry));
+  return nullptr;
+}
+
 /**
  * Refit the weight-stripped engine
  */
@@ -2598,6 +2611,7 @@ TensorrtExecutionProvider::TensorrtExecutionProvider(TensorrtExecutionProviderFa
   Compile = CompileImpl;
   ReleaseNodeComputeInfos = ReleaseNodeComputeInfosImpl;
   CreateSyncStreamForDevice = CreateSyncStreamForDeviceImpl;
+  GetKernelRegistry = GetKernelRegistryImpl;
 
   // Initialize the execution provider.
 
@@ -3978,4 +3992,5 @@ void TRTEpEpContextNodeComputeInfo::ReleaseStateImpl(OrtNodeComputeInfo* this_pt
   (void)trt_ep_compute_state;
   // Do nothing for here.
 }
+
 }  // namespace trt_ep

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
@@ -6,10 +6,6 @@
 #include <numeric>
 #include <cuda_runtime.h>
 
-#define ORT_API_MANUAL_INIT
-#include "onnxruntime_cxx_api.h"
-#undef ORT_API_MANUAL_INIT
-
 #define ORT_EP_UTILS_ORT_GRAPH_TO_PROTO_IMPL
 #include "ort_graph_to_proto.h"
 

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.cc
@@ -6,7 +6,9 @@
 #include <numeric>
 #include <cuda_runtime.h>
 
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
 
 #define ORT_EP_UTILS_ORT_GRAPH_TO_PROTO_IMPL
 #include "ort_graph_to_proto.h"

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider.h
@@ -271,6 +271,10 @@ struct TensorrtExecutionProvider : public OrtEp, public ApiPtrs {
                                                                _In_ const OrtMemoryDevice* memory_device,
                                                                _Outptr_ OrtSyncStreamImpl** stream) noexcept;
 
+  static OrtStatus* ORT_API_CALL TensorrtExecutionProvider::GetKernelRegistryImpl(
+      _In_ OrtEp* this_ptr,
+      _Outptr_result_maybenull_ const OrtKernelRegistry** kernel_registry) noexcept;
+
   mutable TensorrtExecutionProviderInfo info_;
   int max_partition_iterations_ = 1000;
   size_t min_subgraph_size_ = 1;

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_data_transfer.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_data_transfer.cc
@@ -17,17 +17,22 @@ bool ORT_API_CALL TRTEpDataTransfer::CanCopyImpl(const OrtDataTransferImpl* this
                                                  const OrtMemoryDevice* dst_memory_device) noexcept {
   auto& impl = *static_cast<const TRTEpDataTransfer*>(this_ptr);
 
-  auto it = std::find_if(impl.cuda_gpu_mem_devices_.begin(), impl.cuda_gpu_mem_devices_.end(),
-                         [&impl, &src_memory_device, &dst_memory_device](const OrtMemoryDevice* memory_device) {
-                           bool src_is_our_device = impl.ep_api.MemoryDevice_AreEqual(src_memory_device, memory_device);
-                           bool dst_is_our_device = impl.ep_api.MemoryDevice_AreEqual(dst_memory_device, memory_device);
-                           return src_is_our_device || dst_is_our_device;
-                         });
+  // logic copied from GPUDataTransfer::CanCopy
+  OrtMemoryInfoDeviceType src_type = impl.ep_api.MemoryDevice_GetDeviceType(src_memory_device);
+  OrtMemoryInfoDeviceType dst_type = impl.ep_api.MemoryDevice_GetDeviceType(dst_memory_device);
+  auto src_vendor_id = impl.ep_api.MemoryDevice_GetVendorId(src_memory_device);
+  auto dst_vendor_id = impl.ep_api.MemoryDevice_GetVendorId(dst_memory_device);
 
-  if (it != impl.cuda_gpu_mem_devices_.end()) {
-    return true;
+  // 0x10DE is the PCI vendor ID for NVIDIA
+  if ((src_type == OrtMemoryInfoDeviceType_GPU && src_vendor_id != 0x10DE) ||
+      (dst_type == OrtMemoryInfoDeviceType_GPU && dst_vendor_id != 0x10DE)) {
+    return false;
   }
-  return false;
+
+  // copy must be GPU to GPU or between GPU and CPU
+  return (src_type == OrtMemoryInfoDeviceType_GPU && dst_type == OrtMemoryInfoDeviceType_GPU) ||
+         (src_type == OrtMemoryInfoDeviceType_GPU && dst_type == OrtMemoryInfoDeviceType_CPU) ||
+         (src_type == OrtMemoryInfoDeviceType_CPU && dst_type == OrtMemoryInfoDeviceType_GPU);
 }
 
 // function to copy one or more tensors.

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_data_transfer.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_data_transfer.cc
@@ -24,8 +24,11 @@ bool ORT_API_CALL TRTEpDataTransfer::CanCopyImpl(const OrtDataTransferImpl* this
   auto dst_vendor_id = impl.ep_api.MemoryDevice_GetVendorId(dst_memory_device);
 
   // 0x10DE is the PCI vendor ID for NVIDIA
-  if ((src_type == OrtMemoryInfoDeviceType_GPU && src_vendor_id != 0x10DE) ||
-      (dst_type == OrtMemoryInfoDeviceType_GPU && dst_vendor_id != 0x10DE)) {
+  constexpr uint32_t nvidia_vendor_id = 0x10DE;
+
+  // Reject if GPU device is not NVIDIA
+  if ((src_type == OrtMemoryInfoDeviceType_GPU && src_vendor_id != nvidia_vendor_id) ||
+      (dst_type == OrtMemoryInfoDeviceType_GPU && dst_vendor_id != nvidia_vendor_id)) {
     return false;
   }
 

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <vector>
+
+#include "tensorrt_execution_provider_kernel_registration.h"
+#include "kernels/utils.h"
+
+namespace trt_ep {
+
+// Table of BuildKernelCreateInfo functions for each operator
+static const BuildKernelCreateInfoFn build_kernel_create_info_funcs[] = {
+
+  BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kOnnxDomain, 1, MemcpyFromHost)>,
+  BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kOnnxDomain, 1, MemcpyToHost)>,
+
+};
+
+size_t GetNumKernels() {
+  return std::size(build_kernel_create_info_funcs);
+}
+
+static OrtStatus* RegisterKernels(Ort::KernelRegistry& kernel_registry, const char* ep_name,
+                                  void* create_kernel_state) {
+  for (auto& build_func : build_kernel_create_info_funcs) {
+    KernelCreateInfo kernel_create_info = {};
+    RETURN_IF_ERROR(build_func(ep_name, create_kernel_state, &kernel_create_info));
+
+    if (kernel_create_info.kernel_def != nullptr) {
+      RETURN_IF_ERROR(kernel_registry.AddKernel(kernel_create_info.kernel_def,
+                                                kernel_create_info.kernel_create_func,
+                                                kernel_create_info.kernel_create_func_state));
+    }
+  }
+
+  return nullptr;
+}
+
+OrtStatus* CreateKernelRegistry(const char* ep_name, void* create_kernel_state,
+                                OrtKernelRegistry** out_kernel_registry) {
+  *out_kernel_registry = nullptr;
+
+  if (GetNumKernels() == 0) {
+    return nullptr;
+  }
+
+  try {
+    Ort::KernelRegistry kernel_registry;
+    Ort::Status status{RegisterKernels(kernel_registry, ep_name, create_kernel_state)};
+
+    *out_kernel_registry = status.IsOK() ? kernel_registry.release() : nullptr;
+    return status.release();
+  } catch (const Ort::Exception& ex) {
+    Ort::Status status(ex);
+    return status.release();
+  } catch (const std::exception& ex) {
+    Ort::Status status(ex.what(), ORT_EP_FAIL);
+    return status.release();
+  }
+}
+
+}  // namespace trt_ep

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <vector>
+
+#include "ep_utils.h"
+
+namespace trt_ep {
+
+size_t GetNumKernels();
+
+OrtStatus* CreateKernelRegistry(const char* ep_name, void* create_kernel_state, OrtKernelRegistry** kernel_registry);
+
+}  // namespace trt_ep

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_kernel_registration.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include "ep_utils.h"
 
 namespace trt_ep {

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_stream_support.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_stream_support.h
@@ -58,7 +58,7 @@ struct TrtSyncNotificationImpl : public OrtSyncNotificationImpl, public ApiPtrs 
   static OrtStatus* ORT_API_CALL WaitOnHostImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept;
   static void ORT_API_CALL ReleaseImpl(_In_ OrtSyncNotificationImpl* this_ptr) noexcept;
 
-  cudaStream_t& stream_;
+  cudaStream_t stream_;
   cudaEvent_t event_;
 };
 }  // namespace trt_ep

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_utils.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
 
 #include "ep_utils.h"
 #include "flatbuffers/idl.h"

--- a/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_utils.h
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_execution_provider_utils.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#define ORT_API_MANUAL_INIT
-#include "onnxruntime_cxx_api.h"
-#undef ORT_API_MANUAL_INIT
-
 #include "ep_utils.h"
 #include "flatbuffers/idl.h"
 #include "ort_trt_int8_cal_table.fbs.h"

--- a/plugin_execution_providers/tensorrt/src/tensorrt_provider_factory.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_provider_factory.cc
@@ -1,4 +1,7 @@
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
+
 #include "tensorrt_provider_factory.h"
 #include "tensorrt_execution_provider.h"
 #include "tensorrt_execution_provider_kernel_registration.h"
@@ -310,6 +313,9 @@ EXPORT_SYMBOL OrtStatus* CreateEpFactories(const char* registration_name, const 
   const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
   const OrtEpApi* ort_ep_api = ort_api->GetEpApi();
   const OrtModelEditorApi* model_editor_api = ort_api->GetModelEditorApi();
+
+  // Manual init for the C++ API
+  Ort::InitApi(ort_api);
 
   // Factory could use registration_name or define its own EP name.
   std::unique_ptr<OrtEpFactory> factory = std::make_unique<trt_ep::TensorrtExecutionProviderFactory>(registration_name, *default_logger, ApiPtrs{*ort_api, *ort_ep_api, *model_editor_api});

--- a/plugin_execution_providers/tensorrt/src/tensorrt_provider_factory.cc
+++ b/plugin_execution_providers/tensorrt/src/tensorrt_provider_factory.cc
@@ -1,7 +1,3 @@
-#define ORT_API_MANUAL_INIT
-#include "onnxruntime_cxx_api.h"
-#undef ORT_API_MANUAL_INIT
-
 #include "tensorrt_provider_factory.h"
 #include "tensorrt_execution_provider.h"
 #include "tensorrt_execution_provider_kernel_registration.h"

--- a/plugin_execution_providers/tensorrt/src/utils/ep_utils.h
+++ b/plugin_execution_providers/tensorrt/src/utils/ep_utils.h
@@ -4,14 +4,7 @@
 #include "onnxruntime_cxx_api.h"
 #undef ORT_API_MANUAL_INIT
 
-// #include "flatbuffers/idl.h"
-// #include "ort_trt_int8_cal_table.fbs.h"
 #include "make_string.h"
-// #include "core/providers/cuda/cuda_pch.h"
-// #include "core/common/path_string.h"
-// #include "core/framework/murmurhash3.h"
-
-// #include"nv_includes.h"
 #include "gsl/narrow"
 
 #include <fstream>

--- a/plugin_execution_providers/tensorrt/src/utils/ep_utils.h
+++ b/plugin_execution_providers/tensorrt/src/utils/ep_utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
 
 // #include "flatbuffers/idl.h"
 // #include "ort_trt_int8_cal_table.fbs.h"

--- a/plugin_execution_providers/tensorrt/src/utils/ort_graph_to_proto.h
+++ b/plugin_execution_providers/tensorrt/src/utils/ort_graph_to_proto.h
@@ -123,7 +123,9 @@
 
 #include <functional>
 #include <optional>
+#define ORT_API_MANUAL_INIT
 #include "onnxruntime_cxx_api.h"
+#undef ORT_API_MANUAL_INIT
 #include "onnx/onnx_pb.h"
 
 namespace OrtEpUtils {


### PR DESCRIPTION
This PR has following changes:

1. Add `MemcpyToHost` and `MemcpyFromHost` kernels for plugin TRT EP that implements `OrtKernelImpl`.
2. Make TensorRT plugin ep code define `ORT_API_MANUAL_INIT` so the DLL won't take dependency on onnxruntime.dll (otherwise, when compiling/linking TensorRT plugin EP DLL, OrtGetApiBase() will be needed from onnxruntime.dll) 