### PR TITLE
Allow subscriptionless PR dispatcher login

### DIFF
--- a/.github/workflows/extended-pr-validation.yml
+++ b/.github/workflows/extended-pr-validation.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           client-id: ${{ secrets.ADO_PR_CLIENT_ID }}
           tenant-id: ${{ secrets.ADO_PR_TENANT_ID }}
-          subscription-id: ${{ secrets.ADO_PR_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Select pull request revision
         id: revision


### PR DESCRIPTION
The dispatcher service principal intentionally has no Azure subscription role because it only requests an Azure DevOps bearer token. Configure azure/login for tenant-only authentication instead of granting unnecessary Azure RBAC.

The OIDC federation itself is now verified: GitHub's immutable customized subject matched successfully before azure/login rejected the missing subscription.