### PR TITLE
Fix MNIST ranges algorithm build

### DIFF
--- a/c_cxx/MNIST/MNIST.cpp
+++ b/c_cxx/MNIST/MNIST.cpp
@@ -5,6 +5,7 @@
 #include <windows.h>
 
 // C++20 Standard Library
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <format>


### PR DESCRIPTION
## Summary
- include <algorithm> for the C++20 std::ranges algorithms used by the Windows MNIST sample

## Validation
- compiled and ran a focused MSVC /std:c++20 check covering std::ranges::fill and std::ranges::minmax`n- VS Code reports no diagnostics