### PR TITLE
Validate private pipeline dispatcher identity

### DIFF
--- a/.github/workflows/extended-pr-validation.yml
+++ b/.github/workflows/extended-pr-validation.yml
@@ -31,6 +31,7 @@ jobs:
       ADO_ORGANIZATION: ${{ secrets.ADO_PR_ORGANIZATION }}
       ADO_PROJECT: ${{ secrets.ADO_PR_PROJECT }}
       ADO_PIPELINE_ID: ${{ secrets.ADO_PR_PIPELINE_ID }}
+      ADO_PR_OBJECT_ID: ${{ secrets.ADO_PR_OBJECT_ID }}
 
     steps:
       - name: Sign in for private validation
@@ -76,7 +77,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          for variable in ADO_ORGANIZATION ADO_PROJECT ADO_PIPELINE_ID; do
+          for variable in ADO_ORGANIZATION ADO_PROJECT ADO_PIPELINE_ID ADO_PR_OBJECT_ID; do
             if [[ -z "${!variable:-}" ]]; then
               echo "Required dispatcher configuration is unavailable." >&2
               exit 1
@@ -88,6 +89,18 @@ jobs:
             --query accessToken \
             --output tsv)"
           echo "::add-mask::${ado_token}"
+
+          token_payload="${ado_token#*.}"
+          token_payload="${token_payload%%.*}"
+          case $((${#token_payload} % 4)) in
+            2) token_payload="${token_payload}==" ;;
+            3) token_payload="${token_payload}=" ;;
+          esac
+          token_object_id="$(printf '%s' "$token_payload" | tr '_-' '/+' | base64 --decode 2>/dev/null | jq -er '.oid')"
+          if [[ "$token_object_id" != "$ADO_PR_OBJECT_ID" ]]; then
+            echo "Azure DevOps token identity does not match the configured dispatcher." >&2
+            exit 1
+          fi
 
           organization="${ADO_ORGANIZATION%/}"
           project="$(jq -rn --arg value "$ADO_PROJECT" '$value | @uri')"


### PR DESCRIPTION
Adds a fail-closed check that the Azure DevOps access token belongs to the service principal whose private pipeline permissions are configured. The workflow reports only a generic mismatch and does not expose either object ID.\n\nThe expected object ID is stored in the repository Actions secret ADO_PR_OBJECT_ID.