### PR TITLE
Use live pull request merge revisions

### DIFF
--- a/.github/workflows/extended-pr-validation.yml
+++ b/.github/workflows/extended-pr-validation.yml
@@ -47,17 +47,15 @@ jobs:
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
 
-          if [[ -z "$MERGE_COMMIT" ]]; then
-            for attempt in {1..6}; do
-              MERGE_COMMIT="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/pull/${PR_NUMBER}/merge" | awk '{print $1}')"
-              [[ -n "$MERGE_COMMIT" ]] && break
-              sleep 5
-            done
-          fi
+          MERGE_COMMIT=""
+          for attempt in {1..6}; do
+            MERGE_COMMIT="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "refs/pull/${PR_NUMBER}/merge" | awk '{print $1}')"
+            [[ -n "$MERGE_COMMIT" ]] && break
+            sleep 5
+          done
           if [[ -z "$MERGE_COMMIT" ]]; then
             echo "GitHub did not create a merge ref for this pull request." >&2
             exit 1
@@ -136,7 +134,7 @@ jobs:
                 "${build_api}/${run_id}?api-version=7.1" || true
             fi
           }
-          trap cancel_build INT TERM
+            trap cancel_build EXIT INT TERM
 
           payload="$(jq -n \
             --arg pipeline_id "$ADO_PIPELINE_ID" \
@@ -182,6 +180,7 @@ jobs:
               result="$(jq -er '.result' response.json)"
               rm response.json
               echo "Private validation completed with result: ${result}."
+              run_id=""
               [[ "$result" == "succeeded" ]]
               exit
             fi


### PR DESCRIPTION
Always resolves refs/pull/<number>/merge at job execution time instead of trusting the event's cached merge_commit_sha, which can be null or stale during rapid synchronize events.\n\nAlso cancels the queued Azure DevOps build whenever the monitoring shell exits before Azure reports completion. This prevents superseded PR runs from leaving private builds active.