### PR TITLE
Fix CI runner regressions

### DIFF
--- a/.github/actions/setup-android-ndk/action.yml
+++ b/.github/actions/setup-android-ndk/action.yml
@@ -18,6 +18,13 @@ runs:
       shell: bash
       run: sudo apt-get update -y && sudo apt-get install -y coreutils ninja-build
 
+    - name: Enable KVM access
+      shell: bash
+      run: |
+        if [[ -e /dev/kvm ]]; then
+          sudo chmod 666 /dev/kvm
+        fi
+
     - name: Install Android NDK
       shell: bash
       run: |

--- a/.github/workflows/extended-pr-validation.yml
+++ b/.github/workflows/extended-pr-validation.yml
@@ -47,6 +47,7 @@ jobs:
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -57,11 +58,13 @@ jobs:
             sleep 5
           done
           if [[ -z "$MERGE_COMMIT" ]]; then
-            echo "GitHub did not create a merge ref for this pull request." >&2
-            exit 1
+            echo "GitHub did not create a merge ref; validating the pull request head instead."
+            echo "source_ref=refs/pull/${PR_NUMBER}/head" >> "$GITHUB_OUTPUT"
+            echo "source_commit=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_ref=refs/pull/${PR_NUMBER}/merge" >> "$GITHUB_OUTPUT"
+            echo "source_commit=${MERGE_COMMIT}" >> "$GITHUB_OUTPUT"
           fi
-          echo "source_ref=refs/pull/${PR_NUMBER}/merge" >> "$GITHUB_OUTPUT"
-          echo "source_commit=${MERGE_COMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Select manual revision
         id: manual_revision

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -53,7 +53,7 @@ jobs:
 
   WhisperLocalAndroid:
     name: Whisper Local Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -94,7 +94,7 @@ jobs:
 
   WhisperAzureAndroid:
     name: Whisper Azure Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -209,7 +209,7 @@ jobs:
 
   ObjectDetectionAndroid:
     name: Object Detection Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -250,7 +250,7 @@ jobs:
 
   ImageClassificationAndroid:
     name: Image Classification Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     strategy:
       matrix: 
         ModelFormat: [onnx, ort]
@@ -302,7 +302,7 @@ jobs:
 
   SuperResolutionAndroid:
     name: Super Resolution Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -364,7 +364,7 @@ jobs:
 
   QuestionAnsweringAndroid:
     name: Question Answering Android
-    runs-on: ["self-hosted", "1ES.Pool=onnxruntime-examples-Ubuntu2204-CPU"]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
         # Test against multiple Node.js versions
         node-version: [20.x, 22.x, 24.x]
         arch: [x64]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,8 +17,19 @@ jobs:
         # Test against multiple Node.js versions
         node-version: [20.x, 22.x, 24.x]
         arch: [x64]
+        exclude:
+          - os: macos-latest
         include:
           - os: ubuntu-latest
+            arch: arm64
+          - os: macos-latest
+            node-version: 20.x
+            arch: arm64
+          - os: macos-latest
+            node-version: 22.x
+            arch: arm64
+          - os: macos-latest
+            node-version: 24.x
             arch: arm64
     steps:
     - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15-intel]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         # Test against multiple Node.js versions
         node-version: [20.x, 22.x, 24.x]
         arch: [x64]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,8 @@ jobs:
           &${{ github.workspace }}\ci_build\download_ort_release 1.22.1
 
       - name: Config cmake
-        run: npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_C_FLAGS="/MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -DCMAKE_CXX_FLAGS="/EHsc /MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif --merge-runs
+        run: |
+          npm i -g @microsoft/sarif-multitool && mkdir b && cd b && cmake ../c_cxx -DCMAKE_C_FLAGS="/MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -DCMAKE_CXX_FLAGS="/EHsc /MP /analyze:external- /external:anglebrackets /DWIN32 /D_WINDOWS /DWINVER=0x0A00 /D_WIN32_WINNT=0x0A00 /DNTDDI_VERSION=0x0A000000 /W4 /Ob0 /Od /RTC1 /analyze:autolog:ext .sarif" -A x64 -T host=x64 -DONNXRUNTIME_ROOTDIR=${{ github.workspace }}\onnxruntimebin && cmake --build . --config Debug && npx @microsoft/sarif-multitool merge *.sarif --recurse --output-directory=${{ github.workspace }}\output --output-file=MergeResult.sarif
 
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8

--- a/js/quick-start_onnxruntime-node/package.json
+++ b/js/quick-start_onnxruntime-node/package.json
@@ -6,5 +6,8 @@
   "main": "index.js",
   "dependencies": {
     "onnxruntime-node": "^1.23.0"
+  },
+  "allowScripts": {
+    "onnxruntime-node": true
   }
 }


### PR DESCRIPTION
## Summary
- remove the obsolete `--merge-runs` SARIF Multitool option from Windows CI
- approve the `onnxruntime-node` postinstall script required to install native bindings under npm 11
- run macOS Node tests natively on ARM64 to match the hosted runner and bundled Darwin binding
- run Android tests on GitHub-hosted Ubuntu with KVM instead of the unavailable 1ES pool
- fetch full Git history so lintrunner can resolve the merge base with `origin/main`
- fall back to the immutable pull request head when GitHub has not generated a merge ref yet

These failures were exposed by the checks on #566 and subsequent validation runs on this PR.

## Validation
- reproduced npm 11.17's blocked `onnxruntime-node` postinstall and verified the unpinned `allowScripts` policy
- installed the native binding and ran the Node quick-start example successfully
- passed all 10 Node.js matrix jobs, including macOS Node 20, 22, and 24 on ARM64
- passed all seven Android jobs on GitHub-hosted Ubuntu, including emulator setup and instrumentation tests
- parsed all GitHub Actions workflow YAML files
- ran `lintrunner` with no lint issues
- checked all edited workflows with VS Code diagnostics
- verified the SARIF Multitool 5.6.0 merge options
- verified the pull request head ref resolves to the API-reported head SHA