### PR TITLE
Restrict basic C# sample package source

### DIFF
--- a/plugin_execution_providers/basic/csharp/nuget.config
+++ b/plugin_execution_providers/basic/csharp/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="local_feed" value="./local_feed" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This pull request makes a small configuration update to the NuGet package sources for the C# plugin execution provider. The change ensures that only the explicitly defined `local_feed` source is used.

* [`plugin_execution_providers/basic/csharp/nuget.config`](diffhunk://#diff-12e329dd16e02f00517cba3aeda5e54870e5a7208e2dede3d29282eb3f05171dR4): Added the `<clear />` tag to remove any default or previously defined package sources, ensuring only `local_feed` is available.